### PR TITLE
Refactor prototype into ES modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,8 @@
 
 <div id="fx"></div>
 
-<script>
+<script type="module" src="./src/main.js"></script>
+<script nomodule>
 (() => {
 // ===== Utilities =====
 const lerp = (a,b,t)=>a+(b-a)*t;
@@ -88,7 +89,7 @@ function fitCanvas(){
   canvas.style.height = h+"px";
   canvas.width = Math.floor(w*dpr);
   canvas.height = Math.floor(h*dpr);
-  ctx.setTransform(dpr,0,0,dpr,0,0); // draw in CSS pixels
+  ctx.setTransform(dpr,0,0,dpr,0,0);
 }
 window.addEventListener('resize', fitCanvas);
 fitCanvas();
@@ -109,7 +110,7 @@ window.addEventListener('keydown', e=>{
 });
 window.addEventListener('keyup', e=> keys.delete(e.key.toLowerCase()));
 
-// ===== Audio (tiny bleeps) =====
+// ===== Audio =====
 let audioOn = true;
 let ac, master;
 function initAudio(){
@@ -137,13 +138,13 @@ function pow(){ beep('sine', 560, 0.25, 0.28); }
 // ===== Game State =====
 const state = {
   running:false, paused:false,
-  levelDur: 90, // seconds, target 1–2 minutes
+  levelDur: 90,
   time:0, score:0, lives:3,
   player:null,
   bullets:[], enemies:[], enemyBullets:[], particles:[],
   stars:[], powerups:[], finishGate:null,
-  lastShot:0, shotDelay:180, // ms
-  speed: 260, // scroll speed (px/s)
+  lastShot:0, shotDelay:180,
+  speed: 260,
   scrollY: 0,
   power: {name:null, until:0}
 };
@@ -163,14 +164,14 @@ function makePlayer(){
   const p = {
     x: canvas.width/2, y: canvas.height*0.75,
     vx:0, vy:0, speed:260, r:14,
-    shield:0, // time left in ms
+    shield:0,
     invuln:0
   };
   state.player = p;
 }
 makePlayer();
 
-// ===== Entities Helpers =====
+// ===== Entity Helpers =====
 function coll(a,b, pad=0){
   const dx=a.x-b.x, dy=a.y-b.y;
   const rr = (a.r||0)+(b.r||0)+pad;
@@ -185,10 +186,9 @@ function addParticle(x,y, col, count=10, spread=2, life=400){
   }
 }
 
-// ===== Enemies =====
+// ===== Enemies and Power-ups =====
 function spawnWave(t){
   const w = canvas.width;
-  // Asteroids
   if (t%900<16){
     const n = 5+Math.floor(Math.random()*3);
     for(let i=0;i<n;i++){
@@ -198,7 +198,6 @@ function spawnWave(t){
       });
     }
   }
-  // Strafers
   if (t%1400<16){
     const dir = Math.random()<0.5?-1:1;
     for(let i=0;i<3;i++){
@@ -208,7 +207,6 @@ function spawnWave(t){
       });
     }
   }
-  // Homing drones
   if (t%2000<16){
     for(let i=0;i<2;i++){
       state.enemies.push({
@@ -216,7 +214,6 @@ function spawnWave(t){
       });
     }
   }
-  // Turret platforms
   if (t%2600<16){
     for(let i=0;i<2;i++){
       state.enemies.push({
@@ -224,14 +221,12 @@ function spawnWave(t){
       });
     }
   }
-  // Powerup every 12s
   if (t%12000<16){
     const kind = ['shield','rapid','boost'][Math.floor(Math.random()*3)];
     state.powerups.push({type:kind, x:rand(40,w-40), y:-30, vy:110, r:12, t:9000});
   }
 }
 
-// ===== Power-ups =====
 function givePower(kind){
   const now = performance.now();
   const dur = 8000;
@@ -295,32 +290,24 @@ function drawGlowCircle(x,y,r, c1, c2){
   ctx.fillStyle=g; ctx.beginPath(); ctx.arc(x,y,r,0,TAU); ctx.fill();
 }
 function drawShip(p){
-  // body
   ctx.save();
   ctx.translate(p.x, p.y);
   const tilt = clamp((keys.has('arrowleft')||keys.has('a')?-1:0)+(keys.has('arrowright')||keys.has('d')?1:0), -1, 1);
   ctx.rotate(tilt*0.08);
-  // engine trail
   const engLen = 14 + (Math.sin(performance.now()*0.02)+1)*6;
   const trail = ctx.createLinearGradient(0,0,0,30);
   trail.addColorStop(0,'#00e5ffcc'); trail.addColorStop(1,'#ff3df700');
   ctx.fillStyle=trail;
   ctx.beginPath(); ctx.moveTo(0,10); ctx.lineTo(-6,24+engLen); ctx.lineTo(6,24+engLen); ctx.closePath(); ctx.fill();
-
-  // hull
   ctx.shadowColor='#00e5ff88'; ctx.shadowBlur=12;
   ctx.fillStyle='#0ae6ff'; ctx.strokeStyle='#ff3df7';
   ctx.lineWidth=1.6;
   ctx.beginPath();
   ctx.moveTo(0,-16); ctx.lineTo(12,10); ctx.lineTo(0,16); ctx.lineTo(-12,10); ctx.closePath();
   ctx.fill(); ctx.stroke();
-
-  // canopy
   ctx.shadowBlur=0;
   ctx.fillStyle='#1efcff';
   ctx.beginPath(); ctx.ellipse(0,-6,5,7,0,0,TAU); ctx.fill();
-
-  // shield
   if (p.shield>0){
     ctx.globalAlpha = 0.6 + 0.4*Math.sin(performance.now()*0.01);
     drawGlowCircle(0,0,p.r+6,'#00e5ff55','#00e5ff00');
@@ -340,7 +327,7 @@ function drawEnemy(e){
   if (e.type==='asteroid'){
     ctx.shadowColor='#00e5ff55'; ctx.shadowBlur=6;
     ctx.fillStyle='#11293b'; ctx.strokeStyle='#00e5ff66'; ctx.lineWidth=1;
-    ctx.beginPath(); for(let i=0;i<7;i++){ const ang=i/7*TAU, rr=e.r+rand(-4,4); ctx.lineTo(Math.cos(ang)*rr, Math.sin(ang)*rr);} ctx.closePath();
+    ctx.beginPath(); for(let i=0;i<7;i++){ const ang=i/7*TAU, rr=e.r+rand(-4,4); ctx.lineTo(Math.cos(ang)*rr, Math.sin(ang)*rr); } ctx.closePath();
     ctx.fill(); ctx.stroke();
   } else if (e.type==='strafer'){
     ctx.shadowColor='#ff3df799'; ctx.shadowBlur=10;
@@ -384,7 +371,6 @@ function drawGate(g){
   ctx.fillStyle='#00e5ff';
   ctx.fillRect(-w/2,-h/2,w,h);
   ctx.shadowBlur=0;
-  // Magenta pillars
   ctx.strokeStyle='#ff3df7'; ctx.lineWidth=3;
   ctx.beginPath();
   ctx.moveTo(-w/2, -40); ctx.lineTo(-w/2, 40);
@@ -400,12 +386,10 @@ function loop(now){
   const dt = (now - lastFrame)/1000; lastFrame = now;
   if (state.paused){ requestAnimationFrame(loop); return; }
 
-  // Timer & finish
   state.time += dt;
   hudTime.textContent = Math.floor(state.time);
   if (state.time>=state.levelDur && !state.finishGate){ ensureFinishGate(); }
 
-  // Background stars
   ctx.clearRect(0,0,canvas.width,canvas.height);
   for (const s of state.stars){
     s.y += (60*s.z + state.speed*0.05* s.z) * dt;
@@ -416,10 +400,8 @@ function loop(now){
   }
   ctx.globalAlpha = 1;
 
-  // Input → player movement
   const p = state.player;
   const accel = (state.power.name==='boost')? 560: 380;
-  const decel = 0.0008;
   const up   = keys.has('arrowup')||keys.has('w');
   const down = keys.has('arrowdown')||keys.has('s');
   const left = keys.has('arrowleft')||keys.has('a');
@@ -432,7 +414,6 @@ function loop(now){
   p.x = clamp(p.x, 20, canvas.width-20);
   p.y = clamp(p.y, 40, canvas.height-40);
 
-  // Shooting
   const rapid = state.power.name==='rapid';
   const delay = rapid ? 90 : state.shotDelay;
   if ((keys.has(' ') || keys.has('space')) && now - state.lastShot > delay){
@@ -445,17 +426,14 @@ function loop(now){
     pew();
   }
 
-  // Update bullets
   for (let i=state.bullets.length-1;i>=0;i--){
     const b = state.bullets[i];
     b.y += b.vy*dt;
     if (b.y<-30) state.bullets.splice(i,1);
   }
 
-  // Spawn enemies/powerups
   spawnWave(now);
 
-  // Update enemies
   for (let i=state.enemies.length-1;i>=0;i--){
     const e = state.enemies[i];
     if (e.type==='asteroid'){
@@ -482,11 +460,9 @@ function loop(now){
         state.enemyBullets.push({x:e.x, y:e.y, vx: Math.cos(angle)*220, vy: Math.sin(angle)*220, r:6});
       }
     }
-    // Offscreen clean-up
     if (e.y>canvas.height+80) { state.enemies.splice(i,1); continue; }
   }
 
-  // Update enemy bullets
   for (let i=state.enemyBullets.length-1;i>=0;i--){
     const b = state.enemyBullets[i];
     b.x += (b.vx||0)*dt;
@@ -494,7 +470,6 @@ function loop(now){
     if (b.y<-40||b.y>canvas.height+40||b.x<-40||b.x>canvas.width+40) state.enemyBullets.splice(i,1);
   }
 
-  // Update powerups
   for (let i=state.powerups.length-1;i>=0;i--){
     const pu = state.powerups[i];
     pu.y += pu.vy*dt;
@@ -507,19 +482,16 @@ function loop(now){
   }
   clearExpiredPowers(now);
 
-  // Finish gate
   if (state.finishGate){
     const g = state.finishGate;
     g.y += g.vy*dt;
     if (g.y > canvas.height*0.25) g.vy = 0;
     if (Math.abs(p.y - g.y) < 28 && Math.abs(p.x - g.x) < g.w/2){
-      // Win
       zap(); zap(); pow();
       gameOver(true); return;
     }
   }
 
-  // Collisions bullets ↔ enemies
   for (let i=state.enemies.length-1;i>=0;i--){
     const e = state.enemies[i];
     for (let j=state.bullets.length-1;j>=0;j--){
@@ -539,13 +511,12 @@ function loop(now){
     }
   }
 
-  // Collisions player with enemy/enemyBullets
   function playerHit(){
     if (p.shield>0){ p.shield-=400; addParticle(p.x,p.y,'#00e5ff',20,3,400); hit(); return; }
     if (p.invuln>0) return;
     state.lives--; hudLives.textContent = state.lives;
     addParticle(p.x,p.y,'#ff3df7',30,3.2,500); zap();
-    p.invuln = 2000; // ms
+    p.invuln = 2000;
     if (state.lives<=0){ gameOver(false); }
   }
   for (const e of state.enemies){
@@ -556,8 +527,6 @@ function loop(now){
   }
   if (p.invuln>0) p.invuln -= dt*1000;
 
-  // Draw entities
-  // Powerups below enemies for clarity
   for (const pu of state.powerups) drawPowerUp(pu);
   for (const e of state.enemies) drawEnemy(e);
   for (const b of state.enemyBullets) drawEnemyBullet(b);
@@ -565,7 +534,6 @@ function loop(now){
   if (state.finishGate) drawGate(state.finishGate);
   drawShip(p);
 
-  // Particles
   for (let i=state.particles.length-1;i>=0;i--){
     const q = state.particles[i];
     q.t -= dt*1000; q.x += q.vx; q.y += q.vy;
@@ -575,14 +543,13 @@ function loop(now){
     ctx.globalAlpha = 1;
   }
 
-  // Score tick
   state.score += Math.floor(30*dt);
   hudScore.textContent = state.score;
 
   requestAnimationFrame(loop);
 }
 
-// ===== Controls: pause, mute, fullscreen =====
+// ===== Controls =====
 document.addEventListener('keydown', e=>{
   if (!state.running) return;
   if (e.key.toLowerCase()==='p'){
@@ -599,10 +566,7 @@ document.addEventListener('keydown', e=>{
   }
 });
 
-// Start button
 startBtn.onclick = start;
-
-// Resume audio on user gesture if blocked
 window.addEventListener('click', ()=>{ if (ac && ac.state==='suspended') ac.resume(); }, {once:false});
 })();
 </script>

--- a/src/audio.js
+++ b/src/audio.js
@@ -1,0 +1,84 @@
+/**
+ * audio.js — lightweight synthesised audio cues for Retro Space Run.
+ */
+let audioOn = true;
+let ac;
+let master;
+
+function ensureAudio() {
+  if (ac) {
+    return;
+  }
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  if (!Ctx) {
+    audioOn = false;
+    return;
+  }
+  ac = new Ctx();
+  master = ac.createGain();
+  master.gain.value = 0.12;
+  master.connect(ac.destination);
+}
+
+function playTone(type, freq, len, gain) {
+  if (!audioOn) {
+    return;
+  }
+  ensureAudio();
+  if (!ac) {
+    return;
+  }
+  const osc = ac.createOscillator();
+  const g = ac.createGain();
+  osc.type = type;
+  osc.frequency.value = freq;
+  g.gain.value = gain;
+  osc.connect(g);
+  g.connect(master);
+  const t = ac.currentTime;
+  osc.start(t);
+  g.gain.exponentialRampToValueAtTime(0.0001, t + len);
+  osc.stop(t + len + 0.02);
+}
+
+export function playZap() {
+  playTone('sawtooth', 320, 0.12, 0.25);
+}
+
+export function playPew() {
+  playTone('square', 920, 0.06, 0.25);
+}
+
+export function playHit() {
+  playTone('triangle', 180, 0.2, 0.35);
+}
+
+export function playPow() {
+  playTone('sine', 560, 0.25, 0.28);
+}
+
+export function toggleAudio() {
+  audioOn = !audioOn;
+  if (audioOn) {
+    ensureAudio();
+    playPow();
+  }
+  return audioOn;
+}
+
+export function setAudioEnabled(enabled) {
+  audioOn = enabled;
+  if (audioOn) {
+    ensureAudio();
+  }
+}
+
+export function isAudioEnabled() {
+  return audioOn;
+}
+
+export function resumeAudioContext() {
+  if (ac && ac.state === 'suspended') {
+    ac.resume();
+  }
+}

--- a/src/enemies.js
+++ b/src/enemies.js
@@ -1,0 +1,191 @@
+/**
+ * enemies.js — enemy spawning, behaviour updates, and rendering for Retro Space Run.
+ */
+import { rand, TAU, drawGlowCircle } from './utils.js';
+
+const spawnTimers = {
+  asteroid: 0,
+  strafer: 0,
+  drone: 0,
+  turret: 0,
+};
+
+function shouldSpawn(now, key, interval) {
+  if (now - spawnTimers[key] < interval) {
+    return false;
+  }
+  spawnTimers[key] = now;
+  return true;
+}
+
+export function spawnEnemies(state, now, canvas) {
+  const w = canvas.width;
+  if (shouldSpawn(now, 'asteroid', 900)) {
+    const n = 5 + Math.floor(Math.random() * 3);
+    for (let i = 0; i < n; i++) {
+      state.enemies.push({
+        type: 'asteroid',
+        x: rand(40, w - 40),
+        y: -20 - rand(0, 200),
+        vx: rand(-50, 50),
+        vy: rand(80, 160),
+        r: rand(12, 24),
+        hp: 2,
+      });
+    }
+  }
+  if (shouldSpawn(now, 'strafer', 1400)) {
+    const dir = Math.random() < 0.5 ? -1 : 1;
+    for (let i = 0; i < 3; i++) {
+      state.enemies.push({
+        type: 'strafer',
+        x: dir < 0 ? -30 : w + 30,
+        y: rand(60, canvas.height * 0.5),
+        vx: dir * rand(120, 180),
+        vy: 20 * Math.sin(now * 0.001 + i),
+        r: 14,
+        hp: 3,
+        cd: rand(300, 700),
+      });
+    }
+  }
+  if (shouldSpawn(now, 'drone', 2000)) {
+    for (let i = 0; i < 2; i++) {
+      state.enemies.push({
+        type: 'drone',
+        x: rand(40, w - 40),
+        y: -40,
+        vx: 0,
+        vy: rand(60, 100),
+        r: 12,
+        hp: 2,
+      });
+    }
+  }
+  if (shouldSpawn(now, 'turret', 2600)) {
+    for (let i = 0; i < 2; i++) {
+      state.enemies.push({
+        type: 'turret',
+        x: rand(80, w - 80),
+        y: -30,
+        vx: 0,
+        vy: rand(70, 110),
+        r: 16,
+        hp: 4,
+        cd: 600,
+      });
+    }
+  }
+}
+
+export function updateEnemies(state, dt, now, player, canvas) {
+  for (let i = state.enemies.length - 1; i >= 0; i--) {
+    const e = state.enemies[i];
+    if (e.type === 'asteroid') {
+      e.x += e.vx * dt;
+      e.y += e.vy * dt;
+      if (e.x < -40 || e.x > canvas.width + 40) {
+        e.vx *= -1;
+      }
+    } else if (e.type === 'strafer') {
+      e.x += e.vx * dt;
+      e.y += Math.sin(now * 0.004 + i) * 40 * dt;
+      e.cd -= dt * 1000;
+      if (e.cd <= 0) {
+        e.cd = rand(600, 1100);
+        state.enemyBullets.push({
+          x: e.x,
+          y: e.y + 10,
+          vx: (player.x - e.x) * 0.0025,
+          vy: 180,
+          r: 6,
+        });
+      }
+      if (e.x < -60 || e.x > canvas.width + 60) {
+        state.enemies.splice(i, 1);
+        continue;
+      }
+    } else if (e.type === 'drone') {
+      const dx = player.x - e.x;
+      const dy = player.y - e.y;
+      const d = Math.hypot(dx, dy) + 0.0001;
+      e.vx += (dx / d) * 60 * dt;
+      e.vy += (dy / d) * 60 * dt;
+      e.x += e.vx * dt;
+      e.y += e.vy * dt;
+    } else if (e.type === 'turret') {
+      e.y += e.vy * dt;
+      e.cd -= dt * 1000;
+      if (e.cd <= 0) {
+        e.cd = 600 + Math.random() * 600;
+        const angle = Math.atan2(player.y - e.y, player.x - e.x);
+        state.enemyBullets.push({
+          x: e.x,
+          y: e.y,
+          vx: Math.cos(angle) * 220,
+          vy: Math.sin(angle) * 220,
+          r: 6,
+        });
+      }
+    }
+    if (e.y > canvas.height + 80) {
+      state.enemies.splice(i, 1);
+    }
+  }
+}
+
+export function drawEnemies(ctx, enemies) {
+  for (const e of enemies) {
+    ctx.save();
+    ctx.translate(e.x, e.y);
+    if (e.type === 'asteroid') {
+      ctx.shadowColor = '#00e5ff55';
+      ctx.shadowBlur = 6;
+      ctx.fillStyle = '#11293b';
+      ctx.strokeStyle = '#00e5ff66';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      for (let i = 0; i < 7; i++) {
+        const ang = (i / 7) * TAU;
+        const rr = e.r + rand(-4, 4);
+        ctx.lineTo(Math.cos(ang) * rr, Math.sin(ang) * rr);
+      }
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+    } else if (e.type === 'strafer') {
+      ctx.shadowColor = '#ff3df799';
+      ctx.shadowBlur = 10;
+      ctx.fillStyle = '#2e003b';
+      ctx.strokeStyle = '#ff3df7';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(-14, 0);
+      ctx.lineTo(0, -10);
+      ctx.lineTo(14, 0);
+      ctx.lineTo(0, 10);
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+    } else if (e.type === 'drone') {
+      ctx.shadowColor = '#00e5ffaa';
+      ctx.shadowBlur = 12;
+      drawGlowCircle(ctx, 0, 0, e.r, '#00e5ff88', '#00e5ff00');
+      ctx.fillStyle = '#00e5ff';
+      ctx.fillRect(-2, -2, 4, 4);
+    } else if (e.type === 'turret') {
+      ctx.shadowColor = '#00e5ff88';
+      ctx.shadowBlur = 12;
+      ctx.fillStyle = '#091a2c';
+      ctx.strokeStyle = '#00e5ff';
+      ctx.lineWidth = 1.8;
+      ctx.beginPath();
+      ctx.arc(0, 0, 12, 0, TAU);
+      ctx.fill();
+      ctx.stroke();
+      ctx.fillStyle = '#ff3df7';
+      ctx.fillRect(-2, -8, 4, 8);
+    }
+    ctx.restore();
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,341 @@
+/**
+ * main.js — bootstraps Retro Space Run, orchestrating modules and the core game loop.
+ */
+import { rand, coll, addParticle } from './utils.js';
+import {
+  canvas,
+  ctx,
+  setStartHandler,
+  showOverlay,
+  hideOverlay,
+  showPauseOverlay,
+  updateLives,
+  updateScore,
+  updateTime,
+  updatePower,
+} from './ui.js';
+import { playZap, playHit, toggleAudio, resumeAudioContext, playPow } from './audio.js';
+import { resetPlayer, updatePlayer, clampPlayerToBounds, drawPlayer } from './player.js';
+import { spawnEnemies, updateEnemies, drawEnemies } from './enemies.js';
+import {
+  resetPowerTimers,
+  maybeSpawnPowerup,
+  updatePowerups,
+  drawPowerups,
+  clearExpiredPowers,
+  resetPowerState,
+} from './powerups.js';
+import {
+  handlePlayerShooting,
+  updatePlayerBullets,
+  drawPlayerBullets,
+  updateEnemyBullets,
+  drawEnemyBullets,
+} from './weapons.js';
+
+const state = {
+  running: false,
+  paused: false,
+  levelDur: 90,
+  time: 0,
+  score: 0,
+  lives: 3,
+  player: null,
+  bullets: [],
+  enemies: [],
+  enemyBullets: [],
+  particles: [],
+  powerups: [],
+  stars: [],
+  finishGate: null,
+  lastShot: 0,
+  shotDelay: 180,
+  speed: 260,
+  power: { name: null, until: 0 },
+};
+
+const keys = new Set();
+
+window.addEventListener('keydown', (e) => {
+  if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(e.key)) {
+    e.preventDefault();
+  }
+  keys.add(e.key.toLowerCase());
+  if (!state.running) {
+    return;
+  }
+  const key = e.key.toLowerCase();
+  if (key === 'p') {
+    state.paused = !state.paused;
+    if (state.paused) {
+      showPauseOverlay();
+    } else {
+      hideOverlay();
+    }
+  } else if (key === 'm') {
+    toggleAudio();
+  } else if (key === 'f') {
+    const el = document.documentElement;
+    if (!document.fullscreenElement) {
+      el.requestFullscreen?.();
+    } else {
+      document.exitFullscreen?.();
+    }
+  }
+});
+
+window.addEventListener('keyup', (e) => {
+  keys.delete(e.key.toLowerCase());
+});
+
+window.addEventListener('click', () => {
+  resumeAudioContext();
+});
+
+function spawnStars() {
+  state.stars.length = 0;
+  const count = Math.ceil((canvas.width * canvas.height) / 9000);
+  for (let i = 0; i < count; i++) {
+    state.stars.push({ x: rand(0, canvas.width), y: rand(0, canvas.height), z: rand(0.4, 1.6) });
+  }
+}
+
+function ensureFinishGate() {
+  if (state.finishGate) {
+    return;
+  }
+  state.finishGate = {
+    x: canvas.width / 2,
+    y: -200,
+    vy: 80,
+    w: 240,
+    h: 12,
+  };
+}
+
+function drawGate(gate) {
+  ctx.save();
+  ctx.translate(gate.x, gate.y);
+  const glow = (Math.sin(performance.now() * 0.003) + 1) * 0.5;
+  ctx.shadowColor = '#00e5ffaa';
+  ctx.shadowBlur = 20 + 20 * glow;
+  ctx.fillStyle = '#00e5ff';
+  ctx.fillRect(-gate.w / 2, -gate.h / 2, gate.w, gate.h);
+  ctx.shadowBlur = 0;
+  ctx.strokeStyle = '#ff3df7';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(-gate.w / 2, -40);
+  ctx.lineTo(-gate.w / 2, 40);
+  ctx.moveTo(gate.w / 2, -40);
+  ctx.lineTo(gate.w / 2, 40);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function resetState() {
+  state.running = true;
+  state.paused = false;
+  state.time = 0;
+  state.score = 0;
+  state.lives = 3;
+  state.bullets.length = 0;
+  state.enemies.length = 0;
+  state.enemyBullets.length = 0;
+  state.powerups.length = 0;
+  state.particles.length = 0;
+  state.finishGate = null;
+  state.lastShot = 0;
+  resetPlayer(state, canvas);
+  resetPowerState(state);
+  resetPowerTimers();
+  spawnStars();
+  updateLives(state.lives);
+  updateScore(state.score);
+  updateTime(0);
+  updatePower('—');
+  hideOverlay();
+  keys.clear();
+  lastFrame = performance.now();
+  requestAnimationFrame(loop);
+}
+
+function gameOver(win) {
+  state.running = false;
+  state.paused = false;
+  const time = Math.floor(state.time);
+  const title = win
+    ? '<span class="cyan">MISSION COMPLETE</span>'
+    : '<span class="heart">GAME OVER</span>';
+  const message = win ? 'You reached the finish gate.' : 'You lost all lives.';
+  showOverlay(`
+    <h1>${title}</h1>
+    <p>Score: <strong>${state.score}</strong> · Time: <strong>${time}</strong>s</p>
+    <p>${message} Press Start to try again.</p>
+    <a id="btn">Start</a>
+  `);
+}
+
+function handlePlayerHit() {
+  const player = state.player;
+  if (player.shield > 0) {
+    player.shield -= 400;
+    addParticle(state, player.x, player.y, '#00e5ff', 20, 3, 400);
+    playHit();
+    return false;
+  }
+  if (player.invuln > 0) {
+    return false;
+  }
+  state.lives -= 1;
+  updateLives(state.lives);
+  addParticle(state, player.x, player.y, '#ff3df7', 30, 3.2, 500);
+  playZap();
+  player.invuln = 2000;
+  if (state.lives <= 0) {
+    gameOver(false);
+    return true;
+  }
+  return false;
+}
+
+let lastFrame = 0;
+
+function loop(now) {
+  if (!state.running) {
+    return;
+  }
+  const dt = (now - lastFrame) / 1000;
+  lastFrame = now;
+  if (state.paused) {
+    requestAnimationFrame(loop);
+    return;
+  }
+
+  state.time += dt;
+  updateTime(Math.floor(state.time));
+
+  if (state.time >= state.levelDur && !state.finishGate) {
+    ensureFinishGate();
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  for (const star of state.stars) {
+    star.y += (60 * star.z + state.speed * 0.05 * star.z) * dt;
+    if (star.y > canvas.height) {
+      star.y = -2;
+      star.x = rand(0, canvas.width);
+    }
+    ctx.globalAlpha = 0.4 * star.z;
+    ctx.fillStyle = star.z > 1.1 ? '#00e5ff' : '#ff3df7';
+    ctx.fillRect(star.x, star.y, 2, 2);
+  }
+  ctx.globalAlpha = 1;
+
+  const player = state.player;
+  updatePlayer(player, keys, dt, state.power.name === 'boost');
+  clampPlayerToBounds(player, canvas);
+
+  handlePlayerShooting(state, keys, now);
+  updatePlayerBullets(state, dt);
+
+  spawnEnemies(state, now, canvas);
+  updateEnemies(state, dt, now, player, canvas);
+  updateEnemyBullets(state, dt, canvas);
+
+  maybeSpawnPowerup(state, now, canvas);
+  updatePowerups(state, dt, now, canvas);
+  clearExpiredPowers(state, now);
+
+  if (state.finishGate) {
+    const gate = state.finishGate;
+    gate.y += gate.vy * dt;
+    if (gate.y > canvas.height * 0.25) {
+      gate.vy = 0;
+    }
+    if (Math.abs(player.y - gate.y) < 28 && Math.abs(player.x - gate.x) < gate.w / 2) {
+      playZap();
+      playZap();
+      playPow();
+      gameOver(true);
+      return;
+    }
+  }
+
+  for (let i = state.enemies.length - 1; i >= 0; i--) {
+    const enemy = state.enemies[i];
+    for (let j = state.bullets.length - 1; j >= 0; j--) {
+      const bullet = state.bullets[j];
+      if (coll(enemy, bullet, -4)) {
+        state.bullets.splice(j, 1);
+        enemy.hp -= 1;
+        addParticle(state, enemy.x, enemy.y, enemy.type === 'strafer' ? '#ff3df7' : '#00e5ff', 12, 2.6, 300);
+        if (enemy.hp <= 0) {
+          state.enemies.splice(i, 1);
+          state.score += 25;
+          updateScore(state.score);
+          playHit();
+        }
+        break;
+      }
+    }
+  }
+
+  const playerDefeated = () => {
+    const eliminated = handlePlayerHit();
+    if (eliminated) {
+      return true;
+    }
+    return false;
+  };
+
+  for (const enemy of state.enemies) {
+    if (coll(player, enemy, -4) && playerDefeated()) {
+      return;
+    }
+  }
+  for (const bullet of state.enemyBullets) {
+    if (coll(player, bullet, -2) && playerDefeated()) {
+      return;
+    }
+  }
+
+  if (player.invuln > 0) {
+    player.invuln -= dt * 1000;
+  }
+
+  drawPowerups(ctx, state.powerups);
+  drawEnemies(ctx, state.enemies);
+  drawEnemyBullets(ctx, state.enemyBullets);
+  drawPlayerBullets(ctx, state.bullets);
+  if (state.finishGate) {
+    drawGate(state.finishGate);
+  }
+  drawPlayer(ctx, player, keys);
+
+  for (let i = state.particles.length - 1; i >= 0; i--) {
+    const p = state.particles[i];
+    p.t -= dt * 1000;
+    p.x += p.vx;
+    p.y += p.vy;
+    if (p.t <= 0) {
+      state.particles.splice(i, 1);
+      continue;
+    }
+    ctx.globalAlpha = p.t / p.life;
+    ctx.fillStyle = p.col;
+    ctx.fillRect(p.x, p.y, 2, 2);
+    ctx.globalAlpha = 1;
+  }
+
+  state.score += Math.floor(30 * dt);
+  updateScore(state.score);
+
+  requestAnimationFrame(loop);
+}
+
+function start() {
+  resetState();
+}
+
+setStartHandler(start);

--- a/src/player.js
+++ b/src/player.js
@@ -1,0 +1,90 @@
+/**
+ * player.js — player creation, movement, and rendering helpers for Retro Space Run.
+ */
+import { clamp, lerp, drawGlowCircle } from './utils.js';
+
+export function createPlayer(canvas) {
+  return {
+    x: canvas.width / 2,
+    y: canvas.height * 0.75,
+    vx: 0,
+    vy: 0,
+    speed: 260,
+    r: 14,
+    shield: 0,
+    invuln: 0,
+  };
+}
+
+export function resetPlayer(state, canvas) {
+  state.player = createPlayer(canvas);
+}
+
+export function updatePlayer(player, keys, dt, hasBoost) {
+  const accel = hasBoost ? 560 : 380;
+  const up = keys.has('arrowup') || keys.has('w');
+  const down = keys.has('arrowdown') || keys.has('s');
+  const left = keys.has('arrowleft') || keys.has('a');
+  const right = keys.has('arrowright') || keys.has('d');
+  const ax = (left ? -accel : 0) + (right ? accel : 0);
+  const ay = (up ? -accel * 0.8 : 0) + (down ? accel * 0.8 : 0);
+  player.vx = lerp(player.vx, ax, 0.08);
+  player.vy = lerp(player.vy, ay, 0.08);
+  player.x += player.vx * dt;
+  player.y += player.vy * dt;
+}
+
+export function clampPlayerToBounds(player, canvas) {
+  player.x = clamp(player.x, 20, canvas.width - 20);
+  player.y = clamp(player.y, 40, canvas.height - 40);
+}
+
+export function drawPlayer(ctx, player, keys) {
+  ctx.save();
+  ctx.translate(player.x, player.y);
+  const tilt = clamp(
+    (keys.has('arrowleft') || keys.has('a') ? -1 : 0) +
+      (keys.has('arrowright') || keys.has('d') ? 1 : 0),
+    -1,
+    1,
+  );
+  ctx.rotate(tilt * 0.08);
+
+  const engLen = 14 + (Math.sin(performance.now() * 0.02) + 1) * 6;
+  const trail = ctx.createLinearGradient(0, 0, 0, 30);
+  trail.addColorStop(0, '#00e5ffcc');
+  trail.addColorStop(1, '#ff3df700');
+  ctx.fillStyle = trail;
+  ctx.beginPath();
+  ctx.moveTo(0, 10);
+  ctx.lineTo(-6, 24 + engLen);
+  ctx.lineTo(6, 24 + engLen);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.shadowColor = '#00e5ff88';
+  ctx.shadowBlur = 12;
+  ctx.fillStyle = '#0ae6ff';
+  ctx.strokeStyle = '#ff3df7';
+  ctx.lineWidth = 1.6;
+  ctx.beginPath();
+  ctx.moveTo(0, -16);
+  ctx.lineTo(12, 10);
+  ctx.lineTo(0, 16);
+  ctx.lineTo(-12, 10);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.shadowBlur = 0;
+  ctx.fillStyle = '#1efcff';
+  ctx.beginPath();
+  ctx.ellipse(0, -6, 5, 7, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  if (player.shield > 0) {
+    ctx.globalAlpha = 0.6 + 0.4 * Math.sin(performance.now() * 0.01);
+    drawGlowCircle(ctx, 0, 0, player.r + 6, '#00e5ff55', '#00e5ff00');
+  }
+  ctx.restore();
+}

--- a/src/powerups.js
+++ b/src/powerups.js
@@ -1,0 +1,123 @@
+/**
+ * powerups.js — spawning, application, and rendering of power-ups for Retro Space Run.
+ */
+import { rand, TAU, coll } from './utils.js';
+import { playPow } from './audio.js';
+import { updatePower } from './ui.js';
+
+const spawnState = {
+  last: 0,
+};
+
+const kinds = ['shield', 'rapid', 'boost'];
+
+export function resetPowerTimers() {
+  spawnState.last = performance.now();
+}
+
+export function maybeSpawnPowerup(state, now, canvas) {
+  if (now - spawnState.last < 12000) {
+    return;
+  }
+  spawnState.last = now;
+  const type = kinds[Math.floor(Math.random() * kinds.length)];
+  state.powerups.push({
+    type,
+    x: rand(40, canvas.width - 40),
+    y: -30,
+    vy: 110,
+    r: 12,
+    t: 9000,
+  });
+}
+
+export function applyPower(state, kind, now) {
+  state.power.name = kind;
+  state.power.until = now + 8000;
+  updatePower(kind.toUpperCase());
+  playPow();
+  switch (kind) {
+    case 'shield':
+      state.player.shield = 8000;
+      break;
+    case 'rapid':
+      state.lastShot = 0;
+      break;
+    case 'boost':
+      state.player.speed = 360;
+      break;
+    default:
+      break;
+  }
+}
+
+export function clearExpiredPowers(state, now) {
+  if (state.power.name && now > state.power.until) {
+    if (state.power.name === 'boost') {
+      state.player.speed = 260;
+    }
+    state.player.shield = 0;
+    state.power.name = null;
+    state.power.until = 0;
+    updatePower('—');
+  }
+}
+
+export function updatePowerups(state, dt, now, canvas) {
+  for (let i = state.powerups.length - 1; i >= 0; i--) {
+    const pu = state.powerups[i];
+    pu.y += pu.vy * dt;
+    pu.t -= dt * 1000;
+    if (pu.t <= 0 || pu.y > canvas.height + 30) {
+      state.powerups.splice(i, 1);
+      continue;
+    }
+    if (coll(state.player, pu)) {
+      applyPower(state, pu.type, now);
+      state.powerups.splice(i, 1);
+    }
+  }
+}
+
+export function drawPowerups(ctx, powerups) {
+  for (const p of powerups) {
+    ctx.save();
+    ctx.translate(p.x, p.y);
+    ctx.shadowColor = '#fff';
+    ctx.shadowBlur = 10;
+    if (p.type === 'shield') {
+      ctx.strokeStyle = '#00e5ff';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(0, 0, 10, 0, TAU);
+      ctx.stroke();
+    } else if (p.type === 'rapid') {
+      ctx.strokeStyle = '#ff3df7';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(-8, -6);
+      ctx.lineTo(8, 6);
+      ctx.moveTo(-8, 6);
+      ctx.lineTo(8, -6);
+      ctx.stroke();
+    } else if (p.type === 'boost') {
+      ctx.strokeStyle = '#ffffff';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(0, -10);
+      ctx.lineTo(-6, 8);
+      ctx.lineTo(6, 8);
+      ctx.closePath();
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+}
+
+export function resetPowerState(state) {
+  state.power.name = null;
+  state.power.until = 0;
+  updatePower('—');
+  state.player.shield = 0;
+  state.player.speed = 260;
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,78 @@
+/**
+ * ui.js — canvas sizing, HUD updates, and overlay controls for Retro Space Run.
+ */
+export const canvas = document.getElementById('game');
+export const ctx = canvas.getContext('2d');
+
+const hudLives = document.getElementById('lives');
+const hudScore = document.getElementById('score');
+const hudTime = document.getElementById('time');
+const hudPower = document.getElementById('pup');
+const overlay = document.getElementById('overlay');
+
+function fitCanvas() {
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const w = window.innerWidth;
+  const h = window.innerHeight;
+  canvas.style.width = `${w}px`;
+  canvas.style.height = `${h}px`;
+  canvas.width = Math.floor(w * dpr);
+  canvas.height = Math.floor(h * dpr);
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+window.addEventListener('resize', fitCanvas);
+fitCanvas();
+
+let startHandler = null;
+
+function bindStartButton() {
+  if (!startHandler) {
+    return;
+  }
+  const btn = document.getElementById('btn');
+  if (btn) {
+    btn.onclick = startHandler;
+  }
+}
+
+export function setStartHandler(handler) {
+  startHandler = handler;
+  bindStartButton();
+}
+
+export function showOverlay(html) {
+  overlay.innerHTML = html;
+  overlay.style.display = 'block';
+  bindStartButton();
+}
+
+export function hideOverlay() {
+  overlay.style.display = 'none';
+}
+
+export function showPauseOverlay() {
+  overlay.style.display = 'block';
+  overlay.innerHTML = '<h1>PAUSED</h1><p>Press P to resume</p>';
+  bindStartButton();
+}
+
+export function updateLives(value) {
+  hudLives.textContent = value;
+}
+
+export function updateScore(value) {
+  hudScore.textContent = value;
+}
+
+export function updateTime(value) {
+  hudTime.textContent = value;
+}
+
+export function updatePower(label) {
+  hudPower.textContent = label || '—';
+}
+
+export function currentOverlay() {
+  return overlay;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,41 @@
+/**
+ * utils.js — shared math helpers and lightweight entity utilities for Retro Space Run.
+ */
+export const TAU = Math.PI * 2;
+
+export const lerp = (a, b, t) => a + (b - a) * t;
+
+export const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+
+export const rand = (a, b) => Math.random() * (b - a) + a;
+
+export function coll(a, b, pad = 0) {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const rr = (a.r || 0) + (b.r || 0) + pad;
+  return dx * dx + dy * dy <= rr * rr;
+}
+
+export function addParticle(state, x, y, col, count = 10, spread = 2, life = 400) {
+  for (let i = 0; i < count; i++) {
+    state.particles.push({
+      x,
+      y,
+      vx: rand(-spread, spread),
+      vy: rand(-spread, spread),
+      life,
+      t: life,
+      col,
+    });
+  }
+}
+
+export function drawGlowCircle(ctx, x, y, r, c1, c2) {
+  const g = ctx.createRadialGradient(x, y, r * 0.2, x, y, r * 1.6);
+  g.addColorStop(0, c1);
+  g.addColorStop(1, c2);
+  ctx.fillStyle = g;
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, TAU);
+  ctx.fill();
+}

--- a/src/weapons.js
+++ b/src/weapons.js
@@ -1,0 +1,73 @@
+/**
+ * weapons.js — player and enemy projectile management for Retro Space Run.
+ */
+import { playPew } from './audio.js';
+
+export function handlePlayerShooting(state, keys, now) {
+  const rapid = state.power.name === 'rapid';
+  const delay = rapid ? 90 : state.shotDelay;
+  if ((keys.has(' ') || keys.has('space')) && now - state.lastShot > delay) {
+    state.lastShot = now;
+    const spread = rapid ? 10 : 0;
+    const shots = rapid ? 2 : 1;
+    for (let i = 0; i < shots; i++) {
+      state.bullets.push({
+        x: state.player.x + (i ? spread : -spread),
+        y: state.player.y - 18,
+        vy: -520,
+        r: 6,
+      });
+    }
+    playPew();
+  }
+}
+
+export function updatePlayerBullets(state, dt) {
+  for (let i = state.bullets.length - 1; i >= 0; i--) {
+    const b = state.bullets[i];
+    b.y += b.vy * dt;
+    if (b.y < -30) {
+      state.bullets.splice(i, 1);
+    }
+  }
+}
+
+export function drawPlayerBullets(ctx, bullets) {
+  for (const b of bullets) {
+    ctx.save();
+    ctx.translate(b.x, b.y);
+    ctx.shadowColor = '#ff3df7aa';
+    ctx.shadowBlur = 10;
+    ctx.fillStyle = '#ffb8ff';
+    ctx.fillRect(-2, -6, 4, 10);
+    ctx.restore();
+  }
+}
+
+export function updateEnemyBullets(state, dt, canvas) {
+  for (let i = state.enemyBullets.length - 1; i >= 0; i--) {
+    const b = state.enemyBullets[i];
+    b.x += (b.vx || 0) * dt;
+    b.y += b.vy * dt;
+    if (
+      b.y < -40 ||
+      b.y > canvas.height + 40 ||
+      b.x < -40 ||
+      b.x > canvas.width + 40
+    ) {
+      state.enemyBullets.splice(i, 1);
+    }
+  }
+}
+
+export function drawEnemyBullets(ctx, bullets) {
+  for (const b of bullets) {
+    ctx.save();
+    ctx.translate(b.x, b.y);
+    ctx.shadowColor = '#00e5ffaa';
+    ctx.shadowBlur = 8;
+    ctx.fillStyle = '#8af5ff';
+    ctx.fillRect(-2, -5, 4, 9);
+    ctx.restore();
+  }
+}


### PR DESCRIPTION
## Summary
- move the monolithic game logic into modular ES module files for player, enemies, weapons, audio, power-ups, and shared utilities
- update index.html to load the module entry point while keeping the original single-file script as a <script nomodule> fallback
- add dedicated UI helpers for canvas sizing and HUD updates to support the modular runtime

## Testing
- Not run (manual testing recommended)


------
https://chatgpt.com/codex/tasks/task_e_68e0d7325ba88321b0d9c67b941e1e29