### PR TITLE
Normalise gameplay bounds to CSS pixels

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2,11 +2,13 @@
  * player.js — player creation, movement, and rendering helpers for Retro Space Run.
  */
 import { clamp, lerp, drawGlowCircle } from './utils.js';
+import { getViewSize } from './ui.js';
 
-export function createPlayer(canvas) {
+export function createPlayer() {
+  const { w, h } = getViewSize();
   return {
-    x: canvas.width / 2,
-    y: canvas.height * 0.75,
+    x: (w || 0) / 2,
+    y: (h || 0) * 0.75,
     vx: 0,
     vy: 0,
     speed: 260,
@@ -16,8 +18,8 @@ export function createPlayer(canvas) {
   };
 }
 
-export function resetPlayer(state, canvas) {
-  state.player = createPlayer(canvas);
+export function resetPlayer(state) {
+  state.player = createPlayer();
 }
 
 export function updatePlayer(player, keys, dt, hasBoost) {
@@ -34,9 +36,10 @@ export function updatePlayer(player, keys, dt, hasBoost) {
   player.y += player.vy * dt;
 }
 
-export function clampPlayerToBounds(player, canvas) {
-  player.x = clamp(player.x, 20, canvas.width - 20);
-  player.y = clamp(player.y, 40, canvas.height - 40);
+export function clampPlayerToBounds(player) {
+  const { w, h } = getViewSize();
+  player.x = clamp(player.x, 20, Math.max(w - 20, 20));
+  player.y = clamp(player.y, 40, Math.max(h - 40, 40));
 }
 
 export function drawPlayer(ctx, player, keys, palette) {

--- a/src/powerups.js
+++ b/src/powerups.js
@@ -3,7 +3,7 @@
  */
 import { rand, TAU, coll } from './utils.js';
 import { playPow } from './audio.js';
-import { updatePower } from './ui.js';
+import { updatePower, getViewSize } from './ui.js';
 
 const spawnState = {
   last: 0,
@@ -15,15 +15,18 @@ export function resetPowerTimers() {
   spawnState.last = performance.now();
 }
 
-export function maybeSpawnPowerup(state, now, canvas) {
+export function maybeSpawnPowerup(state, now) {
   if (now - spawnState.last < 12000) {
     return;
   }
   spawnState.last = now;
   const type = kinds[Math.floor(Math.random() * kinds.length)];
+  const { w } = getViewSize();
+  const viewW = Math.max(w, 1);
+  const maxX = Math.max(viewW - 40, 40);
   state.powerups.push({
     type,
-    x: rand(40, canvas.width - 40),
+    x: rand(40, maxX),
     y: -30,
     vy: 110,
     r: 12,
@@ -63,12 +66,14 @@ export function clearExpiredPowers(state, now) {
   }
 }
 
-export function updatePowerups(state, dt, now, canvas) {
+export function updatePowerups(state, dt, now) {
+  const { h } = getViewSize();
+  const viewH = Math.max(h, 1);
   for (let i = state.powerups.length - 1; i >= 0; i--) {
     const pu = state.powerups[i];
     pu.y += pu.vy * dt;
     pu.t -= dt * 1000;
-    if (pu.t <= 0 || pu.y > canvas.height + 30) {
+    if (pu.t <= 0 || pu.y > viewH + 30) {
       state.powerups.splice(i, 1);
       continue;
     }

--- a/src/ui.js
+++ b/src/ui.js
@@ -13,6 +13,10 @@ import {
 export const canvas = document.getElementById('game');
 export const ctx = canvas.getContext('2d');
 
+let DPR = window.devicePixelRatio || 1;
+let VIEW_W = window.innerWidth || canvas.clientWidth || canvas.width || 0;
+let VIEW_H = window.innerHeight || canvas.clientHeight || canvas.height || 0;
+
 const hudLives = document.getElementById('lives');
 const hudScore = document.getElementById('score');
 const hudTime = document.getElementById('time');
@@ -110,8 +114,11 @@ if (themeSelect) {
 
 function fitCanvas() {
   const dpr = Math.min(window.devicePixelRatio || 1, 2);
-  const w = window.innerWidth;
-  const h = window.innerHeight;
+  const w = Math.max(window.innerWidth || canvas.clientWidth || 0, 1);
+  const h = Math.max(window.innerHeight || canvas.clientHeight || 0, 1);
+  DPR = dpr;
+  VIEW_W = w;
+  VIEW_H = h;
   canvas.style.width = `${w}px`;
   canvas.style.height = `${h}px`;
   canvas.width = Math.floor(w * dpr);
@@ -121,6 +128,10 @@ function fitCanvas() {
 
 window.addEventListener('resize', fitCanvas);
 fitCanvas();
+
+export function getViewSize() {
+  return { w: VIEW_W, h: VIEW_H, dpr: DPR };
+}
 
 let startHandler = null;
 

--- a/src/weapons.js
+++ b/src/weapons.js
@@ -3,7 +3,7 @@
  */
 import { coll } from './utils.js';
 import { playPew, playPow } from './audio.js';
-import { updateWeapon } from './ui.js';
+import { updateWeapon, getViewSize } from './ui.js';
 
 const ROMAN = ['I', 'II', 'III'];
 
@@ -124,7 +124,10 @@ export function handlePlayerShooting(state, keys, now) {
   }
 }
 
-export function updatePlayerBullets(state, dt, canvas) {
+export function updatePlayerBullets(state, dt) {
+  const { w, h } = getViewSize();
+  const viewW = Math.max(w, 1);
+  const viewH = Math.max(h, 1);
   for (let i = state.bullets.length - 1; i >= 0; i--) {
     const b = state.bullets[i];
     b.x += (b.vx || 0) * dt;
@@ -132,9 +135,9 @@ export function updatePlayerBullets(state, dt, canvas) {
     b.life = (b.life || 0) - dt * 1000;
     if (
       b.y < -40 ||
-      b.y > canvas.height + 40 ||
+      b.y > viewH + 40 ||
       b.x < -40 ||
-      b.x > canvas.width + 40 ||
+      b.x > viewW + 40 ||
       b.life <= 0
     ) {
       state.bullets.splice(i, 1);
@@ -154,16 +157,19 @@ export function drawPlayerBullets(ctx, bullets) {
   }
 }
 
-export function updateEnemyBullets(state, dt, canvas) {
+export function updateEnemyBullets(state, dt) {
+  const { w, h } = getViewSize();
+  const viewW = Math.max(w, 1);
+  const viewH = Math.max(h, 1);
   for (let i = state.enemyBullets.length - 1; i >= 0; i--) {
     const b = state.enemyBullets[i];
     b.x += (b.vx || 0) * dt;
     b.y += b.vy * dt;
     if (
       b.y < -40 ||
-      b.y > canvas.height + 40 ||
+      b.y > viewH + 40 ||
       b.x < -40 ||
-      b.x > canvas.width + 40
+      b.x > viewW + 40
     ) {
       state.enemyBullets.splice(i, 1);
     }
@@ -218,14 +224,16 @@ export function maybeDropWeaponToken(state, enemy) {
   });
 }
 
-export function updateWeaponDrops(state, dt, canvas) {
+export function updateWeaponDrops(state, dt) {
+  const { h } = getViewSize();
+  const viewH = Math.max(h, 1);
   ensureWeaponState(state);
   for (let i = state.weaponDrops.length - 1; i >= 0; i--) {
     const drop = state.weaponDrops[i];
     drop.y += drop.vy * dt;
     drop.spin = (drop.spin || 0) + dt * 2.4;
     drop.t -= dt * 1000;
-    if (drop.t <= 0 || drop.y > canvas.height + 40) {
+    if (drop.t <= 0 || drop.y > viewH + 40) {
       state.weaponDrops.splice(i, 1);
       continue;
     }


### PR DESCRIPTION
## Summary
- add a DPR-aware `getViewSize` helper so drawing and logic share CSS pixel dimensions
- update the main loop, player bounds, enemies, power-ups, and projectiles to use CSS viewport sizes for spawning, culling, and centring
- tweak asteroid edge bounces and resize handling so entities stay inside the playfield after DPR changes

## Testing
- node --check src/ui.js
- node --check src/main.js
- node --check src/enemies.js
- node --check src/player.js
- node --check src/powerups.js
- node --check src/weapons.js

------
https://chatgpt.com/codex/tasks/task_e_68e114c22cac8321948470cd11039558