### PR TITLE
Add assist mode toggle and refresh onboarding copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,19 @@ Each module imports and exports explicit functions, so you can develop or test c
 
 ---
 
-## ✨ Feature Highlights in v0.2
+## ✨ Feature Highlights in this build
+
+### Level One Difficulty Tuning
+Level one now leans on a shared difficulty configuration so enemy waves, boss integrity, and loot timers can be tuned in one spot. The opening sector ships with calmer spawn intervals, slower projectiles, and a safety weapon drop once you clear 60 % of the run.
+
+### Assist Mode
+Need a hand or want to test comfortably? Toggle Assist Mode from the HUD pill or hit **H** to persist the setting. Assist grants an extra starting life, short bursts of invulnerability after hits, and a 50 % boost to power-up spawn cadence.
 
 ### Persistent Weapon Upgrades
 Destroying priority targets now drops weapon tokens. Collect them to permanently unlock higher-tier blasters that carry across sessions. The `weapons.js` module serialises unlocks to localStorage and reapplies them when a new run starts, letting players build their own loadout ladder.
 
 ### Boss Encounter Flow
 Every sector culminates in a bespoke boss fight. Bosses spawn once the timer crosses the late-stage threshold, lock the finish gate, and shift the soundtrack via `audio.js`. Defeating the boss triggers celebratory particles, reopens the gate, and rolls a guaranteed weapon drop.
-
-### Theme Selector (Coming Soon)
-The new `themes.js` module already defines multiple palettes and event hooks. The UI exposes a placeholder toggle that will become a fully fledged theme selector shortly, allowing players to swap between classic neon, solar flare, and deep space variants without reloading.
 
 ---
 
@@ -53,6 +56,7 @@ For browsers without module support, leave the inline `<script nomodule>…</scr
 | Pause | P |
 | Fullscreen | F |
 | Mute / Unmute | M |
+| Assist toggle | H / HUD pill |
 
 Controllers with standard gamepad mappings inherit from the browser’s default bindings (left stick to steer, face buttons to fire) when available.
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
     padding:.3rem .6rem; border-radius:10px; backdrop-filter:blur(3px);
   }
   #hud .pill{display:inline-block; margin-right:.6rem; padding:.15rem .5rem; border:1px solid #00e5ff66; border-radius:999px; font-size:.9rem}
+  #hud button.pill{background:transparent; color:var(--white); cursor:pointer; font:inherit; text-transform:none; transition:background .2s ease, box-shadow .2s ease;}
+  #hud button.pill:focus-visible{outline:2px solid var(--cyn); outline-offset:2px;}
+  #hud button.pill.is-on{box-shadow:0 0 8px #00e5ff55 inset, 0 0 8px #ff3df755; background:#ffffff10;}
   #msg{
     position:fixed; inset:0; display:flex; align-items:center; justify-content:center;
     pointer-events:none; text-align:center;
@@ -58,6 +61,7 @@
   <span class="pill">Time: <span id="time">0</span>s</span>
   <span class="pill">Weapon: <span id="weapon">Pulse Cannon · I</span></span>
   <span class="pill">Power-up: <span id="pup">—</span></span>
+  <button id="assist-toggle" class="pill" type="button" aria-pressed="false">Assist: Off</button>
   <span class="pill pill--theme">Theme:
     <select id="theme-select" class="hud-theme">
       <option value="synth-horizon">Synth Horizon</option>
@@ -69,9 +73,9 @@
 
 <div id="msg">
   <div class="box" id="overlay">
-    <h1>RETRO <span class="cyan">BRICK</span> <span class="heart">BASH</span> — SPACE RUN</h1>
-    <p>Arrow keys / WASD to move · Space to shoot · P pause · F fullscreen · M mute</p>
-    <p>Reach the <span class="cyan">finish gate</span> while avoiding hazards. Collect power-ups.</p>
+    <h1>RETRO <span class="cyan">SPACE</span> <span class="heart">RUN</span></h1>
+    <p>WASD / Arrow keys to steer · Space to fire · P pause · F fullscreen · M mute · H Assist Mode</p>
+    <p>Reach the <span class="cyan">finish gate</span> with calmer Level&nbsp;1 waves. Assist Mode adds a spare life, gentler drops, and longer invulnerability.</p>
     <a id="btn">Start</a>
   </div>
 </div>

--- a/src/difficulty.js
+++ b/src/difficulty.js
@@ -1,0 +1,21 @@
+/**
+ * difficulty.js — configuration for level tuning.
+ */
+export const DIFFICULTY = {
+  l1: {
+    asteroid: { intervalMs: 1200, vyMin: 60, vyMax: 130 },
+    strafer: { count: 2, fireCdMsMin: 900, fireCdMsMax: 1400 },
+    drone: { steerAccel: 38 },
+    turret: { bulletSpeed: 170 },
+    powerupIntervalMs: 9000,
+    bossHp: 360,
+  },
+  // l2, l3... later
+};
+
+export function getDifficulty(levelIndex) {
+  if (levelIndex === 1) {
+    return DIFFICULTY.l1;
+  }
+  return null;
+}

--- a/src/player.js
+++ b/src/player.js
@@ -2,11 +2,13 @@
  * player.js — player creation, movement, and rendering helpers for Retro Space Run.
  */
 import { clamp, lerp, drawGlowCircle } from './utils.js';
+import { getViewSize } from './ui.js';
 
-export function createPlayer(canvas) {
+export function createPlayer() {
+  const { w, h } = getViewSize();
   return {
-    x: canvas.width / 2,
-    y: canvas.height * 0.75,
+    x: (w || 0) / 2,
+    y: (h || 0) * 0.75,
     vx: 0,
     vy: 0,
     speed: 260,
@@ -16,8 +18,8 @@ export function createPlayer(canvas) {
   };
 }
 
-export function resetPlayer(state, canvas) {
-  state.player = createPlayer(canvas);
+export function resetPlayer(state) {
+  state.player = createPlayer();
 }
 
 export function updatePlayer(player, keys, dt, hasBoost) {
@@ -34,9 +36,10 @@ export function updatePlayer(player, keys, dt, hasBoost) {
   player.y += player.vy * dt;
 }
 
-export function clampPlayerToBounds(player, canvas) {
-  player.x = clamp(player.x, 20, canvas.width - 20);
-  player.y = clamp(player.y, 40, canvas.height - 40);
+export function clampPlayerToBounds(player) {
+  const { w, h } = getViewSize();
+  player.x = clamp(player.x, 20, Math.max(w - 20, 20));
+  player.y = clamp(player.y, 40, Math.max(h - 40, 40));
 }
 
 export function drawPlayer(ctx, player, keys, palette) {

--- a/src/powerups.js
+++ b/src/powerups.js
@@ -3,7 +3,8 @@
  */
 import { rand, TAU, coll } from './utils.js';
 import { playPow } from './audio.js';
-import { updatePower } from './ui.js';
+import { updatePower, getViewSize } from './ui.js';
+import { getDifficulty } from './difficulty.js';
 
 const spawnState = {
   last: 0,
@@ -15,15 +16,22 @@ export function resetPowerTimers() {
   spawnState.last = performance.now();
 }
 
-export function maybeSpawnPowerup(state, now, canvas) {
-  if (now - spawnState.last < 12000) {
+export function maybeSpawnPowerup(state, now) {
+  const difficulty = getDifficulty(state.levelIndex);
+  const interval = difficulty?.powerupIntervalMs ?? 12000;
+  const assistFactor = state.assistEnabled ? 2 / 3 : 1;
+  const targetInterval = interval * assistFactor;
+  if (now - spawnState.last < targetInterval) {
     return;
   }
   spawnState.last = now;
   const type = kinds[Math.floor(Math.random() * kinds.length)];
+  const { w } = getViewSize();
+  const viewW = Math.max(w, 1);
+  const maxX = Math.max(viewW - 40, 40);
   state.powerups.push({
     type,
-    x: rand(40, canvas.width - 40),
+    x: rand(40, maxX),
     y: -30,
     vy: 110,
     r: 12,
@@ -63,12 +71,14 @@ export function clearExpiredPowers(state, now) {
   }
 }
 
-export function updatePowerups(state, dt, now, canvas) {
+export function updatePowerups(state, dt, now) {
+  const { h } = getViewSize();
+  const viewH = Math.max(h, 1);
   for (let i = state.powerups.length - 1; i >= 0; i--) {
     const pu = state.powerups[i];
     pu.y += pu.vy * dt;
     pu.t -= dt * 1000;
-    if (pu.t <= 0 || pu.y > canvas.height + 30) {
+    if (pu.t <= 0 || pu.y > viewH + 30) {
       state.powerups.splice(i, 1);
       continue;
     }


### PR DESCRIPTION
## Summary
- add a central `DIFFICULTY` map and expose helpers so gameplay systems can read level-one tuning values
- apply gentler level-one spawn speeds, counts, boss health, and power-up cadence while keeping canvas-aware maths intact
- guarantee a mid-run weapon token by tracking drops and forcing a spawn after 60% progress if the player is still at base level
- add an Assist Mode HUD toggle + hotkey with persistence, extra life, longer invulnerability, and faster power-up cadence for accessible test runs
- refresh the landing copy and README to highlight the softer level-one curve and Assist Mode controls

## Testing
- node --check src/main.js
- node --check src/enemies.js
- node --check src/powerups.js
- node --check src/weapons.js
- node --check src/difficulty.js
- node --check src/ui.js

------
https://chatgpt.com/codex/tasks/task_e_68e114c22cac8321948470cd11039558