### PR TITLE
Tune Level 1 spawn cadence with staggered offsets

### DIFF
--- a/src/difficulty.js
+++ b/src/difficulty.js
@@ -3,10 +3,13 @@
  */
 export const DIFFICULTY = {
   l1: {
-    asteroid: { intervalMs: 1200, vyMin: 60, vyMax: 130 },
-    strafer: { count: 2, fireCdMsMin: 900, fireCdMsMax: 1400 },
-    drone: { steerAccel: 38 },
-    turret: { bulletSpeed: 170 },
+    spawn: {
+      asteroid: { every: 1200, offset: 0, vyMin: 60, vyMax: 130 },
+      drone: { every: 2200, offset: 900, steerAccel: 28 },
+      strafer: { every: 2000, offset: 600, count: 2, fireCdMin: 1200, fireCdMax: 1800 },
+      turret: { every: 2600, offset: 1300, fireCdMin: 1200, fireCdMax: 1600, bulletSpeed: 140 },
+    },
+    powerupEvery: 9000,
     powerupIntervalMs: 9000,
     bossHp: 360,
   },


### PR DESCRIPTION
## Summary
- add Level 1 spawn configuration with explicit timing offsets and cooldown tuning
- update enemy spawning logic to honour per-type offsets and tuned cooldowns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e12f6d22948321ad416eb1a277a4dc