### PR TITLE
Add projectile lifespan culling, guaranteed Level 1 powerups, and Assist density scaling

### DIFF
--- a/src/difficulty.js
+++ b/src/difficulty.js
@@ -3,10 +3,13 @@
  */
 export const DIFFICULTY = {
   l1: {
-    asteroid: { intervalMs: 1200, vyMin: 60, vyMax: 130 },
-    strafer: { count: 2, fireCdMsMin: 900, fireCdMsMax: 1400 },
-    drone: { steerAccel: 38 },
-    turret: { bulletSpeed: 170 },
+    spawn: {
+      asteroid: { every: 1200, offset: 0, vyMin: 60, vyMax: 130 },
+      drone: { every: 2200, offset: 900, steerAccel: 28 },
+      strafer: { every: 2000, offset: 600, count: 2, fireCdMin: 1200, fireCdMax: 1800 },
+      turret: { every: 2600, offset: 1300, fireCdMin: 1200, fireCdMax: 1600, bulletSpeed: 140 },
+    },
+    powerupEvery: 9000,
     powerupIntervalMs: 9000,
     bossHp: 360,
   },

--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,7 @@ import {
 import {
   resetPowerTimers,
   maybeSpawnPowerup,
+  ensureGuaranteedPowerups,
   updatePowerups,
   drawPowerups,
   clearExpiredPowers,
@@ -78,6 +79,8 @@ const state = {
   shotDelay: 180,
   speed: 260,
   power: { name: null, until: 0 },
+  powerupsGrantedL1: 0,
+  lastGuaranteedPowerup: null,
   weapon: null,
   theme: activePalette,
   assistEnabled: getAssistMode(),
@@ -210,6 +213,8 @@ function resetState() {
   state.bossDefeatedAt = 0;
   state.lastShot = 0;
   state.weaponDropSecured = false;
+  state.powerupsGrantedL1 = 0;
+  state.lastGuaranteedPowerup = null;
   state.theme = activePalette;
   resetPlayer(state);
   resetPowerState(state);
@@ -322,6 +327,7 @@ function loop(now) {
   updateBoss(state, dt, now, player, palette);
   updateEnemyBullets(state, dt);
 
+  ensureGuaranteedPowerups(state, now);
   maybeSpawnPowerup(state, now);
   updatePowerups(state, dt, now);
   updateWeaponDrops(state, dt);

--- a/src/weapons.js
+++ b/src/weapons.js
@@ -121,6 +121,7 @@ function projectileColour(state, index = 0) {
 }
 
 function spawnProjectile(state, projectile) {
+  const bornAt = state.time * 1000;
   state.bullets.push({
     x: state.player.x + projectile.offsetX,
     y: state.player.y + projectile.offsetY,
@@ -129,7 +130,7 @@ function spawnProjectile(state, projectile) {
     r: 6,
     damage: projectile.damage,
     colour: projectileColour(state, projectile.colourIndex ?? 0),
-    life: 1200,
+    bornAt,
   });
 }
 
@@ -150,21 +151,24 @@ export function handlePlayerShooting(state, keys, now) {
   }
 }
 
+const PLAYER_BULLET_MAX_AGE_MS = 3000;
+
 export function updatePlayerBullets(state, dt) {
   const { w, h } = getViewSize();
   const viewW = Math.max(w, 1);
   const viewH = Math.max(h, 1);
+  const nowMs = state.time * 1000;
   for (let i = state.bullets.length - 1; i >= 0; i--) {
     const b = state.bullets[i];
     b.x += (b.vx || 0) * dt;
     b.y += b.vy * dt;
-    b.life = (b.life || 0) - dt * 1000;
+    const age = nowMs - (b.bornAt ?? nowMs);
     if (
       b.y < -40 ||
       b.y > viewH + 40 ||
       b.x < -40 ||
       b.x > viewW + 40 ||
-      b.life <= 0
+      age > PLAYER_BULLET_MAX_AGE_MS
     ) {
       state.bullets.splice(i, 1);
     }
@@ -183,19 +187,24 @@ export function drawPlayerBullets(ctx, bullets) {
   }
 }
 
+const ENEMY_BULLET_MAX_AGE_MS = 3000;
+
 export function updateEnemyBullets(state, dt) {
   const { w, h } = getViewSize();
   const viewW = Math.max(w, 1);
   const viewH = Math.max(h, 1);
+  const nowMs = state.time * 1000;
   for (let i = state.enemyBullets.length - 1; i >= 0; i--) {
     const b = state.enemyBullets[i];
     b.x += (b.vx || 0) * dt;
     b.y += b.vy * dt;
+    const age = nowMs - (b.bornAt ?? nowMs);
     if (
       b.y < -40 ||
       b.y > viewH + 40 ||
       b.x < -40 ||
-      b.x > viewW + 40
+      b.x > viewW + 40 ||
+      age > ENEMY_BULLET_MAX_AGE_MS
     ) {
       state.enemyBullets.splice(i, 1);
     }


### PR DESCRIPTION
## Summary
- add born-at timestamps when spawning player and enemy bullets
- remove bullets once their age exceeds three seconds in the central update loops
- ensure Level 1 always grants two early powerups by scheduling near-player drops when checkpoints are reached
- reduce enemy wave density by roughly thirty percent whenever Assist mode is enabled to ease Level 1 pacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e12f6d22948321ad416eb1a277a4dc