### PR TITLE
Improve HUD weapon naming and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,12 @@
     text-shadow:0 0 6px #00e5ff88, 0 0 12px #ff3df744;
     padding:.3rem .6rem; border-radius:10px; backdrop-filter:blur(3px);
   }
-  #hud .pill{display:inline-block; margin-right:.6rem; padding:.15rem .5rem; border:1px solid #00e5ff66; border-radius:999px; font-size:.9rem}
-  #hud button.pill{background:transparent; color:var(--white); cursor:pointer; font:inherit; text-transform:none; transition:background .2s ease, box-shadow .2s ease;}
+  #hud .pill{display:inline-flex; align-items:center; gap:.4rem; margin-right:.6rem; padding:.15rem .7rem; border:1px solid #00e5ff66; border-radius:999px; font-size:.9rem}
+  #hud .hud-label{position:relative; display:inline-flex; align-items:center; font-size:.75rem; text-transform:uppercase; letter-spacing:.08em; opacity:.78; min-width:5.1rem; justify-content:flex-end;}
+  #hud .hud-label::after{content:':'; margin-left:.35rem; opacity:.6; font-size:.8rem; letter-spacing:0;}
+  #hud .hud-value{font-weight:700; font-variant-numeric:tabular-nums; letter-spacing:.02em;}
+  #hud button.pill{display:inline-flex; align-items:center; background:transparent; color:var(--white); cursor:pointer; font:inherit; text-transform:none; transition:background .2s ease, box-shadow .2s ease;}
+  #hud .pill.pill--theme{gap:.6rem;}
   #hud button.pill:focus-visible{outline:2px solid var(--cyn); outline-offset:2px;}
   #hud button.pill.is-on{box-shadow:0 0 8px #00e5ff55 inset, 0 0 8px #ff3df755; background:#ffffff10;}
   #msg{
@@ -56,13 +60,13 @@
 <div id="wrap"><canvas id="game" width="1280" height="720"></canvas></div>
 
 <div id="hud">
-  <span class="pill">Lives: <span id="lives">3</span></span>
-  <span class="pill">Score: <span id="score">0</span></span>
-  <span class="pill">Time: <span id="time">0</span>s</span>
-  <span class="pill">Weapon: <span id="weapon">Pulse Cannon · I</span></span>
-  <span class="pill">Power-up: <span id="pup">—</span></span>
+  <span class="pill"><span class="hud-label">Lives</span><span id="lives" class="hud-value">3</span></span>
+  <span class="pill"><span class="hud-label">Score</span><span id="score" class="hud-value">0</span></span>
+  <span class="pill"><span class="hud-label">Time</span><span id="time" class="hud-value">0s</span></span>
+  <span class="pill"><span class="hud-label">Weapon</span><span id="weapon" class="hud-value">None</span></span>
+  <span class="pill"><span class="hud-label">Power-up</span><span id="pup" class="hud-value">None</span></span>
   <button id="assist-toggle" class="pill" type="button" aria-pressed="false">Assist: Off</button>
-  <span class="pill pill--theme">Theme:
+  <span class="pill pill--theme"><span class="hud-label">Theme</span>
     <select id="theme-select" class="hud-theme">
       <option value="synth-horizon">Synth Horizon</option>
       <option value="luminous-depths">Luminous Depths</option>
@@ -572,9 +576,15 @@ function addParticle(x,y, col, count=10, spread=2, life=400){
 
 // ===== Weapons =====
 const ROMAN = ['I','II','III'];
+const WEAPON_DISPLAY_NAMES = Object.freeze({
+  pulse: 'Pulse Cannon',
+  twin: 'Twin Blaster',
+  burst: 'Burst Laser',
+  heavy: 'Heavy Plasma',
+});
 const weaponDefs = {
   pulse: {
-    label: 'Pulse Cannon',
+    label: WEAPON_DISPLAY_NAMES.pulse,
     levels: [
       {
         delay: 210,
@@ -613,10 +623,14 @@ function projectileColour(index=0){
 }
 
 function weaponLabel(){
-  const def = weaponDefs[state.weapon.name];
-  if (!def) return '—';
-  const level = Math.min(state.weapon.level, def.levels.length-1);
-  return `${def.label} · ${ROMAN[level] || ROMAN[ROMAN.length-1]}`;
+  const weapon = state.weapon;
+  if (!weapon) return 'None';
+  const def = weaponDefs[weapon.name];
+  if (!def) return 'None';
+  const levels = def.levels || [];
+  const maxIndex = levels.length ? levels.length - 1 : 0;
+  const levelIdx = Math.max(0, Math.min(maxIndex, weapon.level || 0));
+  return `${def.label} – Level ${levelIdx + 1}`;
 }
 
 function resetWeapon(){
@@ -928,7 +942,7 @@ function givePower(kind){
 function clearExpiredPowers(now){
   if (state.power.name && now > state.power.until){
     if (state.power.name==='boost') state.player.speed = 260;
-    state.power.name = null; hudPup.textContent = '—';
+    state.power.name = null; hudPup.textContent = 'None';
     state.player.shield = 0;
   }
 }
@@ -952,8 +966,8 @@ function start(){
   spawnStars(); makePlayer(); resetWeapon();
   hudLives.textContent = state.lives;
   hudScore.textContent = state.score;
-  hudTime.textContent  = 0;
-  hudPup.textContent   = '—';
+  hudTime.textContent  = '0s';
+  hudPup.textContent   = 'None';
   overlay.style.display='none';
   lastFrame = performance.now();
   requestAnimationFrame(loop);
@@ -1081,7 +1095,7 @@ function loop(now){
   if (state.paused){ requestAnimationFrame(loop); return; }
 
   state.time += dt;
-  hudTime.textContent = Math.floor(state.time);
+  hudTime.textContent = `${Math.floor(state.time)}s`;
   if (state.time>=state.levelDur){
     if (!state.bossSpawned){
       spawnBoss();

--- a/src/main.js
+++ b/src/main.js
@@ -224,7 +224,7 @@ function resetState() {
   updateLives(state.lives);
   updateScore(state.score);
   updateTime(0);
-  updatePower('—');
+  updatePower('None');
   hideOverlay();
   keys.clear();
   lastFrame = performance.now();

--- a/src/powerups.js
+++ b/src/powerups.js
@@ -112,7 +112,7 @@ export function clearExpiredPowers(state, now) {
     state.player.shield = 0;
     state.power.name = null;
     state.power.until = 0;
-    updatePower('—');
+    updatePower('None');
   }
 }
 
@@ -173,7 +173,7 @@ export function drawPowerups(ctx, powerups, palette) {
 export function resetPowerState(state) {
   state.power.name = null;
   state.power.until = 0;
-  updatePower('—');
+  updatePower('None');
   state.player.shield = 0;
   state.player.speed = 260;
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -259,15 +259,16 @@ export function updateScore(value) {
 }
 
 export function updateTime(value) {
-  hudTime.textContent = value;
+  const seconds = value ?? 0;
+  hudTime.textContent = `${seconds}s`;
 }
 
 export function updatePower(label) {
-  hudPower.textContent = label || '—';
+  hudPower.textContent = label || 'None';
 }
 
 export function updateWeapon(label) {
-  hudWeapon.textContent = label;
+  hudWeapon.textContent = label || 'None';
 }
 
 export function currentOverlay() {

--- a/src/weapons.js
+++ b/src/weapons.js
@@ -5,11 +5,16 @@ import { coll } from './utils.js';
 import { playPew, playPow } from './audio.js';
 import { updateWeapon, updateScore, getViewSize } from './ui.js';
 
-const ROMAN = ['I', 'II', 'III'];
+export const WEAPON_DISPLAY_NAMES = Object.freeze({
+  pulse: 'Pulse Cannon',
+  twin: 'Twin Blaster',
+  burst: 'Burst Laser',
+  heavy: 'Heavy Plasma',
+});
 
 const weaponDefs = {
   pulse: {
-    label: 'Pulse Cannon',
+    label: WEAPON_DISPLAY_NAMES.pulse,
     levels: [
       {
         delay: 210,
@@ -89,7 +94,7 @@ const weaponDefs = {
     ],
   },
   twin: {
-    label: 'Twin Blaster',
+    label: WEAPON_DISPLAY_NAMES.twin,
     levels: [
       {
         delay: 200,
@@ -219,7 +224,7 @@ const weaponDefs = {
     ],
   },
   burst: {
-    label: 'Burst Laser',
+    label: WEAPON_DISPLAY_NAMES.burst,
     levels: [
       {
         delay: 230,
@@ -389,7 +394,7 @@ const weaponDefs = {
     ],
   },
   heavy: {
-    label: 'Heavy Plasma',
+    label: WEAPON_DISPLAY_NAMES.heavy,
     levels: [
       {
         delay: 300,
@@ -532,23 +537,29 @@ function currentLevel(state) {
 
 function weaponHudLabel(weapon) {
   if (!weapon) {
-    return 'Weapon: —';
+    return 'None';
+  }
+  const name = getWeaponDisplayName(weapon.name);
+  if (!name) {
+    return 'None';
   }
   const def = weaponDefs[weapon.name];
-  if (!def) {
-    return 'Weapon: —';
-  }
-  const numeral = ROMAN[clampLevel(def, weapon.level)] || ROMAN[ROMAN.length - 1];
-  return `Weapon: ${def.label} – ${numeral}`;
+  const levelIndex = def ? clampLevel(def, weapon.level) : 0;
+  const levelLabel = `Level ${levelIndex + 1}`;
+  return `${name} – ${levelLabel}`;
 }
 
 export function getWeaponLabel(weapon) {
   return weaponHudLabel(weapon);
 }
 
+export function getWeaponDisplayName(id) {
+  return WEAPON_DISPLAY_NAMES[id] || null;
+}
+
 export function updateWeaponHud(state) {
-  ensureWeaponState(state);
-  updateWeapon(weaponHudLabel(state.weapon));
+  const weapon = state?.weapon ?? null;
+  updateWeapon(weaponHudLabel(weapon));
 }
 
 export function setupWeapons(state) {


### PR DESCRIPTION
## Summary
- realign HUD pills and update default text so each label/value pair stays consistent
- centralize weapon display names and surface "Name – Level" strings through the live HUD updates
- normalize "None"/seconds formatting for power-ups and timer displays in both module and fallback builds

## Testing
- Manual HUD check in browser

------
https://chatgpt.com/codex/tasks/task_e_68e13fa310e88321842336e9d9aae845