### PR TITLE
Polish theme palettes and add Neon Void option

### DIFF
--- a/src/enemies.js
+++ b/src/enemies.js
@@ -4,6 +4,7 @@
 import { rand, TAU, drawGlowCircle, addParticle, clamp } from './utils.js';
 import { getViewSize } from './ui.js';
 import { getDifficulty } from './difficulty.js';
+import { resolvePaletteSection } from './themes.js';
 
 const spawnTimers = {
   asteroid: -1,
@@ -325,7 +326,7 @@ export function updateBoss(state, dt, now, player, palette) {
   const { w, h } = getViewSize();
   const viewW = Math.max(w, 1);
   const viewH = Math.max(h, 1);
-  const particles = palette?.particles ?? {};
+  const particles = resolvePaletteSection(palette, 'particles');
 
   if (boss.entering) {
     boss.y += boss.vy * dt;
@@ -350,7 +351,7 @@ export function updateBoss(state, dt, now, player, palette) {
     }
     boss.phase = targetPhase;
     boss.phaseFlashTimer = 720;
-    addParticle(state, boss.x, boss.y, particles.bossHit || '#ff3df7', 48, 4.4, 900);
+    addParticle(state, boss.x, boss.y, particles.bossHit, 48, 4.4, 900);
     if (boss.phase === 2) {
       boss.cooldown = 520;
       boss.volleyTimer = 460;
@@ -481,24 +482,24 @@ export function drawBoss(ctx, boss, palette) {
   if (!boss) {
     return;
   }
-  const bossPalette = palette?.boss ?? {};
+  const bossPalette = resolvePaletteSection(palette, 'boss');
   if (boss.warningTimer > 0) {
     const { w, h } = getViewSize();
     const intensity = clamp(boss.warningTimer / 2000, 0, 1);
     const pulse = 0.65 + 0.35 * Math.sin(boss.warningPulse || 0);
     ctx.save();
-    ctx.fillStyle = bossPalette.warningBackdrop || 'rgba(255, 61, 247, 0.12)';
+    ctx.fillStyle = bossPalette.warningBackdrop;
     ctx.globalAlpha = intensity * 0.9;
     ctx.fillRect(0, 0, w, h);
     ctx.globalAlpha = 1;
     ctx.font = 'bold 64px "Segoe UI", sans-serif';
     ctx.textAlign = 'center';
-    ctx.shadowColor = bossPalette.warningGlow || '#ff3df7';
+    ctx.shadowColor = bossPalette.warningGlow;
     ctx.shadowBlur = 28;
-    ctx.strokeStyle = bossPalette.warningStroke || 'rgba(255, 61, 247, 0.8)';
+    ctx.strokeStyle = bossPalette.warningStroke;
     ctx.lineWidth = 3;
     const y = h * 0.2;
-    const fill = bossPalette.warningFill || 'rgba(255, 245, 160, 0.88)';
+    const fill = bossPalette.warningFill;
     ctx.strokeText('WARNING', w / 2, y);
     ctx.fillStyle = fill;
     ctx.globalAlpha = pulse;
@@ -515,24 +516,24 @@ export function drawBoss(ctx, boss, palette) {
   );
   const telegraphPulse = 0.65 + 0.35 * Math.sin((boss.glowPulse || 0) * 2);
   let shadowColor = isPhase3
-    ? bossPalette.shadowPhase3 || '#ffe55c'
+    ? bossPalette.shadowPhase3
     : isPhase2
-      ? bossPalette.shadowPhase2 || '#ff9dfd'
-      : bossPalette.shadowPhase1 || '#ff3df7aa';
+      ? bossPalette.shadowPhase2
+      : bossPalette.shadowPhase1;
   let shadowBlur = isPhase3 ? 46 : isPhase2 ? 40 : 28;
   let strokeStyle = isPhase3
-    ? bossPalette.strokePhase3 || '#ffe066'
+    ? bossPalette.strokePhase3
     : isPhase2
-      ? bossPalette.strokePhase2 || '#ffb5ff'
-      : bossPalette.strokePhase1 || '#ff3df7';
+      ? bossPalette.strokePhase2
+      : bossPalette.strokePhase1;
   if (telegraphStrength > 0.01) {
-    shadowColor = bossPalette.phaseShiftGlow || '#fff6a6';
+    shadowColor = bossPalette.phaseShiftGlow;
     shadowBlur = 52 + telegraphPulse * 12 * clamp(telegraphStrength, 0, 1);
-    strokeStyle = bossPalette.strokePhaseShift || '#fff6a6';
+    strokeStyle = bossPalette.strokePhaseShift;
   }
   ctx.shadowColor = shadowColor;
   ctx.shadowBlur = shadowBlur;
-  ctx.fillStyle = bossPalette.bodyFill || '#1a0524';
+  ctx.fillStyle = bossPalette.bodyFill;
   ctx.strokeStyle = strokeStyle;
   ctx.lineWidth = 3;
   ctx.beginPath();
@@ -545,20 +546,20 @@ export function drawBoss(ctx, boss, palette) {
   ctx.fill();
   ctx.stroke();
   ctx.shadowBlur = 0;
-  const canopyPhase2 = bossPalette.canopyPhase2 || '#ffdbff';
-  const canopyPhase3 = bossPalette.canopyPhase3 || '#fff0b0';
+  const canopyPhase2 = bossPalette.canopyPhase2;
+  const canopyPhase3 = bossPalette.canopyPhase3;
   ctx.fillStyle = isPhase3
     ? canopyPhase3
     : isPhase2
       ? canopyPhase2
-      : bossPalette.canopy || '#ffd0ff';
+      : bossPalette.canopy;
   ctx.fillRect(-14, -16, 28, 32);
   const coreInner = telegraphStrength > 0.01
-    ? bossPalette.phaseShiftGlow || '#fff6a6'
-    : bossPalette.coreGlow || '#ff3df7aa';
+    ? bossPalette.phaseShiftGlow
+    : bossPalette.coreGlow;
   const coreOuter = telegraphStrength > 0.01
-    ? 'rgba(255, 246, 166, 0)'
-    : bossPalette.coreOuter || '#ff3df700';
+    ? bossPalette.phaseShiftOuter
+    : bossPalette.coreOuter;
   drawGlowCircle(
     ctx,
     0,
@@ -567,20 +568,20 @@ export function drawBoss(ctx, boss, palette) {
     coreInner,
     coreOuter,
   );
-  ctx.fillStyle = bossPalette.beam || '#0ae6ff';
+  ctx.fillStyle = bossPalette.beam;
   ctx.fillRect(-4, -10, 8, 20);
-  let trimColor = bossPalette.trim || '#00e5ff';
+  let trimColor = bossPalette.trim;
   if (telegraphStrength > 0.01) {
-    trimColor = bossPalette.phaseShiftTrim || '#ffe066';
+    trimColor = bossPalette.phaseShiftTrim;
   }
   ctx.fillStyle = trimColor;
   ctx.fillRect(-22, 12, 44, 6);
   if (isPhase2) {
-    ctx.fillStyle = bossPalette.phase2Trim || '#ff3df7';
+    ctx.fillStyle = bossPalette.phase2Trim;
     ctx.fillRect(-40, 24, 80, 6);
   }
   if (isPhase3) {
-    ctx.fillStyle = bossPalette.phase3Trim || '#ffe066';
+    ctx.fillStyle = bossPalette.phase3Trim;
     ctx.fillRect(-46, 30, 92, 6);
   }
   if (boss.introTimer > 0) {
@@ -588,8 +589,8 @@ export function drawBoss(ctx, boss, palette) {
     ctx.translate(0, -80);
     ctx.font = '18px "Segoe UI", sans-serif';
     ctx.textAlign = 'center';
-    ctx.fillStyle = bossPalette.introText || '#ff3df7';
-    ctx.shadowColor = bossPalette.introGlow || '#ff3df788';
+    ctx.fillStyle = bossPalette.introText;
+    ctx.shadowColor = bossPalette.introGlow;
     ctx.shadowBlur = 12;
     ctx.fillText('WARNING — CORE GUARDIAN', 0, 0);
     ctx.restore();
@@ -603,39 +604,39 @@ export function drawBossHealth(ctx, boss, palette) {
   }
   const { w } = getViewSize();
   const viewW = Math.max(w, 1);
-  const bossPalette = palette?.boss ?? {};
+  const bossPalette = resolvePaletteSection(palette, 'boss');
   const width = Math.min(viewW * 0.5, 420);
   const x = (viewW - width) / 2;
   const y = 42;
   const ratio = Math.max(0, boss.hp) / boss.maxHp;
   ctx.save();
-  ctx.fillStyle = bossPalette.healthBackground || '#060712cc';
+  ctx.fillStyle = bossPalette.healthBackground;
   ctx.fillRect(x, y, width, 12);
-  ctx.shadowColor = bossPalette.healthShadow || '#ff3df799';
+  ctx.shadowColor = bossPalette.healthShadow;
   ctx.shadowBlur = 14;
-  ctx.fillStyle = bossPalette.healthFill || '#ff3df7';
+  ctx.fillStyle = bossPalette.healthFill;
   ctx.fillRect(x, y, width * ratio, 12);
   ctx.shadowBlur = 0;
-  ctx.strokeStyle = bossPalette.healthStroke || '#00e5ffaa';
+  ctx.strokeStyle = bossPalette.healthStroke;
   ctx.lineWidth = 2;
   ctx.strokeRect(x - 1, y - 1, width + 2, 14);
   ctx.font = '14px "Segoe UI", sans-serif';
   ctx.textAlign = 'center';
-  ctx.fillStyle = bossPalette.healthText || '#e7faff';
+  ctx.fillStyle = bossPalette.healthText;
   ctx.fillText(`Boss Integrity ${Math.ceil(ratio * 100)}%`, viewW / 2, y - 6);
   ctx.restore();
 }
 
 export function drawEnemies(ctx, enemies, palette) {
-  const enemyPalette = palette?.enemies ?? {};
+  const enemyPalette = resolvePaletteSection(palette, 'enemies');
   for (const e of enemies) {
     ctx.save();
     ctx.translate(e.x, e.y);
     if (e.type === 'asteroid') {
-      ctx.shadowColor = enemyPalette.asteroidGlow || '#00e5ff55';
+      ctx.shadowColor = enemyPalette.asteroidGlow;
       ctx.shadowBlur = 6;
-      ctx.fillStyle = enemyPalette.asteroidFill || '#11293b';
-      ctx.strokeStyle = enemyPalette.asteroidStroke || '#00e5ff66';
+      ctx.fillStyle = enemyPalette.asteroidFill;
+      ctx.strokeStyle = enemyPalette.asteroidStroke;
       ctx.lineWidth = 1;
       ctx.beginPath();
       for (let i = 0; i < 7; i++) {
@@ -647,10 +648,10 @@ export function drawEnemies(ctx, enemies, palette) {
       ctx.fill();
       ctx.stroke();
     } else if (e.type === 'strafer') {
-      ctx.shadowColor = enemyPalette.straferGlow || '#ff3df799';
+      ctx.shadowColor = enemyPalette.straferGlow;
       ctx.shadowBlur = 10;
-      ctx.fillStyle = enemyPalette.straferFill || '#2e003b';
-      ctx.strokeStyle = enemyPalette.straferStroke || '#ff3df7';
+      ctx.fillStyle = enemyPalette.straferFill;
+      ctx.strokeStyle = enemyPalette.straferStroke;
       ctx.lineWidth = 1.5;
       ctx.beginPath();
       ctx.moveTo(-14, 0);
@@ -661,29 +662,29 @@ export function drawEnemies(ctx, enemies, palette) {
       ctx.fill();
       ctx.stroke();
     } else if (e.type === 'drone') {
-      ctx.shadowColor = enemyPalette.droneGlowInner || '#00e5ffaa';
+      ctx.shadowColor = enemyPalette.droneGlowInner;
       ctx.shadowBlur = 12;
       drawGlowCircle(
         ctx,
         0,
         0,
         e.r,
-        enemyPalette.droneGlowInner || '#00e5ff88',
-        enemyPalette.droneGlowOuter || '#00e5ff00',
+        enemyPalette.droneGlowInner,
+        enemyPalette.droneGlowOuter,
       );
-      ctx.fillStyle = enemyPalette.droneCore || '#00e5ff';
+      ctx.fillStyle = enemyPalette.droneCore;
       ctx.fillRect(-2, -2, 4, 4);
     } else if (e.type === 'turret') {
-      ctx.shadowColor = enemyPalette.turretGlow || '#00e5ff88';
+      ctx.shadowColor = enemyPalette.turretGlow;
       ctx.shadowBlur = 12;
-      ctx.fillStyle = enemyPalette.turretFill || '#091a2c';
-      ctx.strokeStyle = enemyPalette.turretStroke || '#00e5ff';
+      ctx.fillStyle = enemyPalette.turretFill;
+      ctx.strokeStyle = enemyPalette.turretStroke;
       ctx.lineWidth = 1.8;
       ctx.beginPath();
       ctx.arc(0, 0, 12, 0, TAU);
       ctx.fill();
       ctx.stroke();
-      ctx.fillStyle = enemyPalette.turretBarrel || '#ff3df7';
+      ctx.fillStyle = enemyPalette.turretBarrel;
       ctx.fillRect(-2, -8, 4, 8);
     }
     ctx.restore();

--- a/src/player.js
+++ b/src/player.js
@@ -3,6 +3,7 @@
  */
 import { clamp, lerp, drawGlowCircle } from './utils.js';
 import { getViewSize } from './ui.js';
+import { resolvePaletteSection } from './themes.js';
 
 export function createPlayer() {
   const { w, h } = getViewSize();
@@ -43,7 +44,7 @@ export function clampPlayerToBounds(player) {
 }
 
 export function drawPlayer(ctx, player, keys, palette) {
-  const ship = palette?.ship ?? {};
+  const ship = resolvePaletteSection(palette, 'ship');
   ctx.save();
   ctx.translate(player.x, player.y);
   const tilt = clamp(
@@ -56,8 +57,8 @@ export function drawPlayer(ctx, player, keys, palette) {
 
   const engLen = 14 + (Math.sin(performance.now() * 0.02) + 1) * 6;
   const trail = ctx.createLinearGradient(0, 0, 0, 30);
-  trail.addColorStop(0, ship.trailStart || '#00e5ffcc');
-  trail.addColorStop(1, ship.trailEnd || '#ff3df700');
+  trail.addColorStop(0, ship.trailStart);
+  trail.addColorStop(1, ship.trailEnd);
   ctx.fillStyle = trail;
   ctx.beginPath();
   ctx.moveTo(0, 10);
@@ -66,10 +67,10 @@ export function drawPlayer(ctx, player, keys, palette) {
   ctx.closePath();
   ctx.fill();
 
-  ctx.shadowColor = ship.glow || '#00e5ff88';
+  ctx.shadowColor = ship.glow;
   ctx.shadowBlur = 12;
-  ctx.fillStyle = ship.primary || '#0ae6ff';
-  ctx.strokeStyle = ship.trim || '#ff3df7';
+  ctx.fillStyle = ship.primary;
+  ctx.strokeStyle = ship.trim;
   ctx.lineWidth = 1.6;
   ctx.beginPath();
   ctx.moveTo(0, -16);
@@ -81,7 +82,7 @@ export function drawPlayer(ctx, player, keys, palette) {
   ctx.stroke();
 
   ctx.shadowBlur = 0;
-  ctx.fillStyle = ship.cockpit || '#1efcff';
+  ctx.fillStyle = ship.cockpit;
   ctx.beginPath();
   ctx.ellipse(0, -6, 5, 7, 0, 0, Math.PI * 2);
   ctx.fill();
@@ -93,8 +94,8 @@ export function drawPlayer(ctx, player, keys, palette) {
       0,
       0,
       player.r + 6,
-      ship.shieldInner || '#00e5ff55',
-      ship.shieldOuter || '#00e5ff00',
+      ship.shieldInner,
+      ship.shieldOuter,
     );
   }
   ctx.restore();

--- a/src/powerups.js
+++ b/src/powerups.js
@@ -5,6 +5,7 @@ import { rand, TAU, coll, clamp } from './utils.js';
 import { playPow } from './audio.js';
 import { updatePower, getViewSize } from './ui.js';
 import { getDifficulty } from './difficulty.js';
+import { resolvePaletteSection } from './themes.js';
 
 const spawnState = {
   last: 0,
@@ -135,20 +136,20 @@ export function updatePowerups(state, dt, now) {
 }
 
 export function drawPowerups(ctx, powerups, palette) {
-  const powerPalette = palette?.powerups ?? {};
+  const powerPalette = resolvePaletteSection(palette, 'powerups');
   for (const p of powerups) {
     ctx.save();
     ctx.translate(p.x, p.y);
-    ctx.shadowColor = powerPalette.glow || '#fff';
+    ctx.shadowColor = powerPalette.glow;
     ctx.shadowBlur = 10;
     if (p.type === 'shield') {
-      ctx.strokeStyle = powerPalette.shield || '#00e5ff';
+      ctx.strokeStyle = powerPalette.shield;
       ctx.lineWidth = 2;
       ctx.beginPath();
       ctx.arc(0, 0, 10, 0, TAU);
       ctx.stroke();
     } else if (p.type === 'rapid') {
-      ctx.strokeStyle = powerPalette.rapid || '#ff3df7';
+      ctx.strokeStyle = powerPalette.rapid;
       ctx.lineWidth = 2;
       ctx.beginPath();
       ctx.moveTo(-8, -6);
@@ -157,7 +158,7 @@ export function drawPowerups(ctx, powerups, palette) {
       ctx.lineTo(8, -6);
       ctx.stroke();
     } else if (p.type === 'boost') {
-      ctx.strokeStyle = powerPalette.boost || '#ffffff';
+      ctx.strokeStyle = powerPalette.boost;
       ctx.lineWidth = 2;
       ctx.beginPath();
       ctx.moveTo(0, -10);

--- a/src/themes.js
+++ b/src/themes.js
@@ -83,6 +83,7 @@ export const THEMES = {
         phaseShiftGlow: '#fff6a6',
         strokePhaseShift: '#fff6a6',
         phaseShiftTrim: '#ffe066',
+        phaseShiftOuter: '#fff6a600',
         warningBackdrop: 'rgba(255, 61, 247, 0.16)',
         warningFill: 'rgba(255, 245, 160, 0.9)',
         warningStroke: 'rgba(255, 61, 247, 0.85)',
@@ -192,6 +193,7 @@ export const THEMES = {
         phaseShiftGlow: '#bffbff',
         strokePhaseShift: '#bffbff',
         phaseShiftTrim: '#9bf0ff',
+        phaseShiftOuter: '#bffbff00',
         warningBackdrop: 'rgba(36, 245, 217, 0.14)',
         warningFill: 'rgba(201, 255, 255, 0.92)',
         warningStroke: 'rgba(22, 128, 255, 0.8)',
@@ -301,6 +303,7 @@ export const THEMES = {
         phaseShiftGlow: '#ffeaa0',
         strokePhaseShift: '#ffeaa0',
         phaseShiftTrim: '#ffe47a',
+        phaseShiftOuter: '#ffeaa000',
         warningBackdrop: 'rgba(255, 123, 57, 0.16)',
         warningFill: 'rgba(255, 228, 122, 0.92)',
         warningStroke: 'rgba(255, 189, 45, 0.82)',
@@ -332,7 +335,125 @@ export const THEMES = {
       },
     },
   },
+  'neon-void': {
+    label: 'Neon Void',
+    palette: {
+      background: {
+        gradient:
+          'radial-gradient(1200px 800px at 50% 20%, #1b0130 0%, #0a0019 60%, #030008 100%)',
+        base: '#0a0019',
+      },
+      hud: {
+        text: '#f1eaff',
+        shadow: '#6dff8d88',
+        panel: '#130021cc',
+        accent: '#c43dff',
+        secondary: '#6dff8d',
+      },
+      ship: {
+        primary: '#c43dff',
+        trim: '#6dff8d',
+        cockpit: '#f6d6ff',
+        glow: '#c43dff88',
+        trailStart: '#c43dffcc',
+        trailEnd: '#6dff8d00',
+        shieldInner: '#6dff8d55',
+        shieldOuter: '#c43dff00',
+      },
+      gate: {
+        glow: '#6dff8daa',
+        fill: '#6dff8d',
+        trim: '#c43dff',
+        strut: '#c43dff',
+      },
+      stars: {
+        bright: '#6dff8d',
+        dim: '#c43dff',
+      },
+      particles: {
+        shieldHit: '#6dff8d',
+        playerHit: '#c43dff',
+        enemyHitDefault: '#6dff8d',
+        enemyHitStrafer: '#c43dff',
+        bossHit: '#c43dff',
+        bossCore: '#6dff8d',
+      },
+      enemies: {
+        asteroidFill: '#201334',
+        asteroidStroke: '#6dff8d66',
+        asteroidGlow: '#6dff8d55',
+        straferFill: '#1a022f',
+        straferStroke: '#c43dff',
+        straferGlow: '#c43dff99',
+        droneGlowInner: '#6dff8d88',
+        droneGlowOuter: '#c43dff00',
+        droneCore: '#6dff8d',
+        turretFill: '#150423',
+        turretStroke: '#6dff8d',
+        turretGlow: '#6dff8d88',
+        turretBarrel: '#c43dff',
+      },
+      boss: {
+        shadowPhase1: '#c43dffaa',
+        shadowPhase2: '#de8bff',
+        shadowPhase3: '#e4ff71',
+        bodyFill: '#1b0327',
+        strokePhase1: '#c43dff',
+        strokePhase2: '#6dff8d',
+        strokePhase3: '#e4ff71',
+        canopy: '#f9d4ff',
+        canopyPhase2: '#e9ffe1',
+        canopyPhase3: '#faffdb',
+        coreGlow: '#c43dffaa',
+        coreOuter: '#6dff8d00',
+        beam: '#6dff8d',
+        trim: '#6dff8d',
+        phase2Trim: '#c43dff',
+        phase3Trim: '#e4ff71',
+        phaseShiftGlow: '#e7ff8a',
+        strokePhaseShift: '#e7ff8a',
+        phaseShiftTrim: '#e4ff71',
+        phaseShiftOuter: '#e7ff8a00',
+        warningBackdrop: 'rgba(196, 61, 255, 0.16)',
+        warningFill: 'rgba(232, 255, 139, 0.92)',
+        warningStroke: 'rgba(109, 255, 141, 0.85)',
+        warningGlow: '#c43dff',
+        introText: '#c43dff',
+        introGlow: '#c43dff88',
+        healthBackground: '#12001bcc',
+        healthFill: '#c43dff',
+        healthShadow: '#c43dff99',
+        healthStroke: '#6dff8daa',
+        healthText: '#f1eaff',
+      },
+      bullets: {
+        playerLevels: ['#f3b7ff', '#d7ffed', '#f4ffe1'],
+        enemyGlow: '#6dff8daa',
+        enemyFill: '#b6ffd0',
+      },
+      weaponToken: {
+        fill: '#c43dff',
+        stroke: '#6dff8d',
+        glow: '#c43dffaa',
+        text: '#6dff8d',
+      },
+      powerups: {
+        glow: '#faffff',
+        shield: '#6dff8d',
+        rapid: '#c43dff',
+        boost: '#faffff',
+      },
+    },
+  },
 };
+
+export const DEFAULT_THEME_PALETTE = THEMES[DEFAULT_THEME_KEY].palette;
+
+export function resolvePaletteSection(palette, section) {
+  const base = DEFAULT_THEME_PALETTE[section] ?? {};
+  const override = palette?.[section];
+  return { ...base, ...(override ?? {}) };
+}
 
 export function getThemeKeys() {
   return Object.keys(THEMES);

--- a/src/ui.js
+++ b/src/ui.js
@@ -67,12 +67,15 @@ function populateThemeControl() {
   if (!themeSelect) {
     return;
   }
-  const keys = getThemeKeys();
+  const entries = getThemeKeys()
+    .map((key) => ({ key, label: getThemeLabel(key) }))
+    .sort((a, b) => a.label.localeCompare(b.label));
   themeSelect.innerHTML = '';
-  for (const key of keys) {
+  for (const { key, label } of entries) {
     const option = document.createElement('option');
     option.value = key;
-    option.textContent = getThemeLabel(key);
+    option.textContent = label;
+    option.setAttribute('aria-label', label);
     themeSelect.appendChild(option);
   }
 }


### PR DESCRIPTION
## Summary
- expand the palette data for existing themes, add the Neon Void theme, and expose a default palette helper
- remove hard-coded colour fallbacks by routing rendering through palette lookups across the game modules
- improve the theme selector’s option labels so players see readable names in the dropdown

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1456e4a8083219f68cdd8730f5dd4