### PR TITLE
Move enemy spawns to declarative level scheduler

### DIFF
--- a/src/difficulty.js
+++ b/src/difficulty.js
@@ -4,12 +4,28 @@
 export const DIFFICULTY = {
   l1: {
     spawn: {
-      asteroid: { every: 1200, offset: 0, vyMin: 60, vyMax: 130 },
-      drone: { every: 2200, offset: 900, steerAccel: 28 },
-      strafer: { every: 2000, offset: 600, count: 2, fireCdMin: 1200, fireCdMax: 1800 },
-      turret: { every: 2600, offset: 1300, fireCdMin: 1200, fireCdMax: 1600, bulletSpeed: 140 },
+      asteroid: { density: 1, countRange: [5, 7], vyMin: 60, vyMax: 130 },
+      drone: { density: 1, count: 2, steerAccel: 28, vyMin: 60, vyMax: 100 },
+      strafer: {
+        density: 1,
+        count: 2,
+        fireCdMin: 1200,
+        fireCdMax: 1800,
+        speedMin: 120,
+        speedMax: 180,
+        yMin: 60,
+        yMax: 0.5,
+      },
+      turret: {
+        density: 1,
+        count: 2,
+        fireCdMin: 1200,
+        fireCdMax: 1600,
+        bulletSpeed: 140,
+        vyMin: 70,
+        vyMax: 110,
+      },
     },
-    powerupEvery: 9000,
     powerupIntervalMs: 9000,
     bossHp: 360,
   },

--- a/src/levels.js
+++ b/src/levels.js
@@ -1,0 +1,62 @@
+/**
+ * levels.js — declarative wave schedules for Retro Space Run.
+ */
+
+const LEVEL1_DURATION = 90;
+const level1Waves = [];
+
+const pushRepeatingWaves = (waves, { start, every, duration, type, count, params }) => {
+  for (let t = start; t < duration; t += every) {
+    waves.push({
+      at: Number(t.toFixed(3)),
+      type,
+      ...(count !== undefined ? { count } : {}),
+      ...(params ? { params } : {}),
+    });
+  }
+};
+
+pushRepeatingWaves(level1Waves, {
+  start: 0,
+  every: 1.2,
+  duration: LEVEL1_DURATION,
+  type: 'asteroid',
+});
+
+pushRepeatingWaves(level1Waves, {
+  start: 0.6,
+  every: 2,
+  duration: LEVEL1_DURATION,
+  type: 'strafer',
+});
+
+pushRepeatingWaves(level1Waves, {
+  start: 0.9,
+  every: 2.2,
+  duration: LEVEL1_DURATION,
+  type: 'drone',
+});
+
+pushRepeatingWaves(level1Waves, {
+  start: 1.3,
+  every: 2.6,
+  duration: LEVEL1_DURATION,
+  type: 'turret',
+});
+
+level1Waves.sort((a, b) => a.at - b.at);
+
+const level1Boss = {
+  kind: 'standard',
+  hp: 360,
+  phases: [0.7, 0.4],
+};
+
+export const LEVELS = [
+  {
+    name: 'Asteroid Run',
+    duration: LEVEL1_DURATION,
+    waves: level1Waves,
+    boss: level1Boss,
+  },
+];


### PR DESCRIPTION
## Summary
- add a declarative level definition in `levels.js` that schedules level 1 waves and boss metadata
- introduce a level scheduler in `main.js` that uses difficulty multipliers to call the refactored `enemies.spawn` helpers and drive boss/gate timing from level data
- refactor `enemies.js` spawn routines and difficulty settings so enemy spawning is parameterised and assist scaling continues to work

## Testing
- node --check src/main.js
- node --check src/enemies.js
- node --check src/levels.js
- node --check src/difficulty.js

------
https://chatgpt.com/codex/tasks/task_e_68e14bd855f8832184db197da4fb004c