### PR TITLE
Add clear boss phase transitions with beam attack

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ import {
   updateBoss,
   drawBoss,
   drawBossHealth,
+  isPointInBossBeam,
 } from './enemies.js';
 import {
   resetPowerTimers,
@@ -515,8 +516,8 @@ function loop(now) {
           state.score += 600;
           updateScore(state.score);
           if (!defeatedBoss.rewardDropped) {
-            maybeDropWeaponToken(state, { x: defeatedBoss.x, y: defeatedBoss.y });
             defeatedBoss.rewardDropped = true;
+            maybeDropWeaponToken(state, { x: defeatedBoss.x, y: defeatedBoss.y });
           }
           state.boss = null;
           state.bossDefeatedAt = now;
@@ -549,6 +550,10 @@ function loop(now) {
       ctx.restore();
       return;
     }
+  }
+  if (state.boss && isPointInBossBeam(state.boss, player.x, player.y) && playerDefeated()) {
+    ctx.restore();
+    return;
   }
 
   if (player.invuln > 0) {


### PR DESCRIPTION
## Summary
- add explicit boss phase tracking with telegraphed transitions and visual glow cues
- implement new attack patterns including a sweeping beam with safe lanes and drone/ring sequences
- guard against duplicate boss rewards and handle beam collisions in the main loop

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e19f3cff908321b15f4c9ab09743c4