### PR TITLE
Enhance weapon tokens and upgrade feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@
   #hud .hud-label{position:relative; display:inline-flex; align-items:center; font-size:.75rem; text-transform:uppercase; letter-spacing:.08em; opacity:.78; min-width:5.1rem; justify-content:flex-end;}
   #hud .hud-label::after{content:':'; margin-left:.35rem; opacity:.6; font-size:.8rem; letter-spacing:0;}
   #hud .hud-value{font-weight:700; font-variant-numeric:tabular-nums; letter-spacing:.02em;}
+  #weapon{display:inline-flex; align-items:center; gap:.35rem;}
+  #weapon .weapon-icon{display:inline-flex; width:1.1rem; justify-content:center; font-size:.85rem; line-height:1; color:var(--cyn); text-shadow:0 0 8px var(--mag);}
+  #weapon .weapon-text{display:inline-block;}
   #hud button.pill{display:inline-flex; align-items:center; background:transparent; color:var(--white); cursor:pointer; font:inherit; text-transform:none; transition:background .2s ease, box-shadow .2s ease;}
   #hud .pill.pill--theme{gap:.6rem;}
   #hud button.pill:focus-visible{outline:2px solid var(--cyn); outline-offset:2px;}

--- a/src/audio.js
+++ b/src/audio.js
@@ -57,6 +57,11 @@ export function playPow() {
   playTone('sine', 560, 0.25, 0.28);
 }
 
+export function playUpgrade() {
+  playTone('triangle', 760, 0.18, 0.28);
+  playTone('square', 520, 0.12, 0.18);
+}
+
 export function toggleAudio() {
   audioOn = !audioOn;
   if (audioOn) {

--- a/src/main.js
+++ b/src/main.js
@@ -80,6 +80,7 @@ const state = {
   weaponDrops: [],
   weaponDropSecured: false,
   muzzleFlashes: [],
+  weaponPickupFlash: null,
   screenShake: { time: 0, duration: 0, magnitude: 0, offsetX: 0, offsetY: 0 },
   stars: [],
   finishGate: null,
@@ -574,7 +575,7 @@ function loop(now) {
   if (state.finishGate) {
     drawGate(state.finishGate, palette);
   }
-  drawPlayer(ctx, player, keys, palette);
+  drawPlayer(ctx, player, keys, palette, state.weaponPickupFlash);
 
   if (state.boss) {
     drawBossHealth(ctx, state.boss, palette);

--- a/src/player.js
+++ b/src/player.js
@@ -43,7 +43,7 @@ export function clampPlayerToBounds(player) {
   player.y = clamp(player.y, 40, Math.max(h - 40, 40));
 }
 
-export function drawPlayer(ctx, player, keys, palette) {
+export function drawPlayer(ctx, player, keys, palette, weaponFlash = null) {
   const ship = resolvePaletteSection(palette, 'ship');
   ctx.save();
   ctx.translate(player.x, player.y);
@@ -97,6 +97,21 @@ export function drawPlayer(ctx, player, keys, palette) {
       ship.shieldInner,
       ship.shieldOuter,
     );
+  }
+  if (weaponFlash && weaponFlash.t > 0 && weaponFlash.colour) {
+    const alpha = Math.max(0, Math.min(1, weaponFlash.t / weaponFlash.life));
+    if (alpha > 0) {
+      ctx.save();
+      ctx.globalAlpha = 0.85 * alpha;
+      ctx.shadowColor = weaponFlash.colour;
+      ctx.shadowBlur = 18;
+      ctx.fillStyle = weaponFlash.colour;
+      ctx.beginPath();
+      ctx.ellipse(0, -18, 6.5, 9.5, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.shadowBlur = 0;
+      ctx.restore();
+    }
   }
   ctx.restore();
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -281,7 +281,7 @@ function showUpgradeBanner(name, level) {
   if (!cleanName || !cleanLevel) {
     return;
   }
-  const message = `UPGRADE: ${cleanName} ${cleanLevel}`;
+  const message = `UPGRADE: ${cleanName} · ${cleanLevel}`;
   upgradeBanner.textContent = message;
   upgradeBanner.classList.remove('is-visible');
   void upgradeBanner.offsetWidth;
@@ -294,8 +294,16 @@ function showUpgradeBanner(name, level) {
   }, 1200);
 }
 
-export function updateWeapon(label, { flash = false, upgradeName, upgradeLevel } = {}) {
-  hudWeapon.textContent = label || 'None';
+export function updateWeapon(
+  label,
+  { flash = false, upgradeName, upgradeLevel, icon } = {},
+) {
+  const value = label || 'None';
+  if (icon) {
+    hudWeapon.innerHTML = `<span class="weapon-icon" aria-hidden="true">${icon}</span><span class="weapon-text">${value}</span>`;
+  } else {
+    hudWeapon.textContent = value;
+  }
   if (!flash) {
     return;
   }


### PR DESCRIPTION
## Summary
- restyle weapon drop tokens as neon discs with animated rims, icons, and subtle hover motion
- increase pickup radius, add gentle player magnetism, and trigger upgrade SFX plus muzzle flash on collection
- surface matching pictograms in the HUD and update the upgrade banner copy for clearer feedback

## Testing
- Manual verification in browser_container (screenshot attached)


------
https://chatgpt.com/codex/tasks/task_e_68e1a8eb74d483218089f482eae7f83d