### PR TITLE
Introduce multi-level progression with wind mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,11 +58,23 @@
   }
   #msg h1{margin:.2rem 0 0.4rem; font-size:2.2rem}
   #msg p{margin:.2rem 0; opacity:.9}
-  #btn{
-    margin-top:.7rem; display:inline-block; padding:.45rem .8rem; border-radius:999px; cursor:pointer;
-    border:1px solid #00e5ffaa; color:var(--white); text-decoration:none; pointer-events:auto;
-    box-shadow:0 0 12px #00e5ff55 inset, 0 0 12px #00e5ff55;
+  .btn,#btn{
+    margin-top:.7rem; display:inline-flex; align-items:center; justify-content:center; padding:.45rem .8rem;
+    border-radius:999px; cursor:pointer; text-decoration:none; pointer-events:auto; border:1px solid #00e5ffaa;
+    color:var(--white); background:#ffffff0a; font-weight:600; letter-spacing:.04em;
+    box-shadow:0 0 12px #00e5ff33 inset, 0 0 12px #00e5ff44; transition:background .2s ease, box-shadow .2s ease;
   }
+  .btn:hover,#btn:hover{background:#00e5ff18; box-shadow:0 0 16px #00e5ff55 inset, 0 0 18px #00e5ff55;}
+  .btn.btn-secondary{background:#ffffff08; border-color:#00e5ff44; box-shadow:0 0 10px #00e5ff22 inset, 0 0 10px #00e5ff22;}
+  .btn.btn-secondary:hover{background:#00e5ff12;}
+  .overlay-actions{display:flex; flex-wrap:wrap; gap:.75rem; justify-content:center; margin-top:1rem;}
+  .level-select{margin-top:1rem; padding:.75rem; border-radius:12px; border:1px solid #00e5ff22; background:#0a0d1acc; box-shadow:0 0 12px #00e5ff11 inset;}
+  .level-select[hidden]{display:none;}
+  .level-select__label{margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.1em; font-size:.78rem; opacity:.72;}
+  .level-select__grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:.55rem;}
+  .level-select__btn{padding:.45rem .65rem; border-radius:10px; border:1px solid #00e5ff44; background:#ffffff10; color:var(--white); font-weight:600; letter-spacing:.03em; cursor:pointer; transition:background .2s ease, box-shadow .2s ease;}
+  .level-select__btn:hover:not([disabled]){background:#00e5ff15; box-shadow:0 0 12px #00e5ff33 inset,0 0 14px #00e5ff55;}
+  .level-select__btn[disabled],.level-select__btn--locked{border-color:#ffffff22; color:#ffffff55; cursor:not-allowed; background:#ffffff08; box-shadow:none;}
   /* Scanline / vignette */
   #fx{
     position:fixed; inset:0; pointer-events:none; mix-blend-mode:screen;

--- a/src/bullets.js
+++ b/src/bullets.js
@@ -48,7 +48,7 @@ export function freeBullet(bullet) {
   bulletPool.push(bullet);
 }
 
-export function updateBullets(bullets, now, bounds) {
+export function updateBullets(bullets, now, bounds, { windX = 0 } = {}) {
   if (!Array.isArray(bullets) || !bullets.length) {
     return;
   }
@@ -58,7 +58,8 @@ export function updateBullets(bullets, now, bounds) {
     const lastUpdate = bullet.updatedAt ?? now;
     const dt = Math.max(0, (now - lastUpdate) / 1000);
     if (dt > 0) {
-      bullet.x += (bullet.vx ?? 0) * dt;
+      const drift = Number.isFinite(windX) ? windX : 0;
+      bullet.x += (bullet.vx ?? 0) * dt + drift * dt;
       bullet.y += (bullet.vy ?? 0) * dt;
     }
     bullet.updatedAt = now;

--- a/src/difficulty.js
+++ b/src/difficulty.js
@@ -29,12 +29,41 @@ export const DIFFICULTY = {
     powerupIntervalMs: 9000,
     bossHp: 360,
   },
-  // l2, l3... later
+  l2: {
+    spawn: {
+      asteroid: { density: 0.9, countRange: [6, 8], vyMin: 100, vyMax: 180 },
+      drone: { density: 1.2, count: 3, steerAccel: 46, vyMin: 80, vyMax: 130 },
+      strafer: {
+        density: 1.2,
+        count: 3,
+        fireCdMin: 820,
+        fireCdMax: 1320,
+        speedMin: 150,
+        speedMax: 220,
+        yMin: 0.25,
+        yMax: 0.6,
+      },
+      turret: {
+        density: 1.25,
+        count: 2,
+        fireCdMin: 780,
+        fireCdMax: 1260,
+        bulletSpeed: 210,
+        vyMin: 90,
+        vyMax: 140,
+      },
+    },
+    powerupIntervalMs: 8400,
+    bossHp: 420,
+  },
 };
 
 export function getDifficulty(levelIndex) {
   if (levelIndex === 1) {
     return DIFFICULTY.l1;
   }
-  return null;
+  if (levelIndex === 2) {
+    return DIFFICULTY.l2;
+  }
+  return DIFFICULTY.l2 ?? DIFFICULTY.l1;
 }

--- a/src/enemies.js
+++ b/src/enemies.js
@@ -27,6 +27,16 @@ const BEAM_SAFE_LANES = [-0.45, 0.45];
 
 const randInt = (min, max) => Math.floor(rand(min, max + 1));
 
+function enemySquallSpread(state, scale = 1) {
+  const squall = state.weather?.squall;
+  const spread = squall?.active ? squall.enemySpread ?? 0 : 0;
+  if (!spread) {
+    return 0;
+  }
+  const factor = Number.isFinite(scale) ? Math.max(0, scale) : 1;
+  return rand(-spread * factor, spread * factor);
+}
+
 function resolveSpawnCount(baseCount, assistEnabled) {
   if (!assistEnabled) {
     return baseCount;
@@ -196,8 +206,9 @@ function pushBossBullet(state, x, y, speed, angle, radius = 8) {
   const bullet = getBullet();
   bullet.x = x;
   bullet.y = y;
-  bullet.vx = Math.cos(angle) * speed;
-  bullet.vy = Math.sin(angle) * speed;
+  const angleOffset = angle + enemySquallSpread(state, 0.006);
+  bullet.vx = Math.cos(angleOffset) * speed;
+  bullet.vy = Math.sin(angleOffset) * speed;
   bullet.r = radius;
   bullet.bornAt = bornAt;
   bullet.updatedAt = bornAt;
@@ -550,7 +561,7 @@ export function updateEnemies(state, dt, now, player) {
         const bornAt = state.time * 1000;
         bullet.x = e.x;
         bullet.y = e.y + 10;
-        bullet.vx = (player.x - e.x) * 0.0025;
+        bullet.vx = (player.x - e.x) * 0.0025 + enemySquallSpread(state, 0.12);
         bullet.vy = 180;
         bullet.r = 6;
         bullet.bornAt = bornAt;
@@ -580,7 +591,7 @@ export function updateEnemies(state, dt, now, player) {
       e.cd -= dt * 1000;
       if (e.cd <= 0) {
         e.cd = rand(turretCdMin, turretCdMax);
-        const angle = Math.atan2(player.y - e.y, player.x - e.x);
+        const angle = Math.atan2(player.y - e.y, player.x - e.x) + enemySquallSpread(state, 0.005);
         const bullet = getBullet();
         const bornAt = state.time * 1000;
         bullet.x = e.x;

--- a/src/levels.js
+++ b/src/levels.js
@@ -1,50 +1,114 @@
 /**
- * levels.js — declarative wave schedules for Retro Space Run.
+ * levels.js — declarative level schedules and mechanics for Retro Space Run.
  */
 
 const LEVEL1_DURATION = 90;
-const level1Waves = [];
+const LEVEL2_DURATION = 105;
 
-const pushRepeatingWaves = (waves, { start, every, duration, type, count, params }) => {
-  for (let t = start; t < duration; t += every) {
-    waves.push({
+function pushRepeatingWaves(target, { start, every, until, type, count, params }) {
+  if (!Array.isArray(target) || !type || !Number.isFinite(every) || every <= 0) {
+    return;
+  }
+  const begin = Math.max(0, Number(start ?? 0));
+  const end = Math.max(begin, Number(until ?? begin));
+  for (let t = begin; t < end; t += every) {
+    target.push({
       at: Number(t.toFixed(3)),
       type,
-      ...(count !== undefined ? { count } : {}),
-      ...(params ? { params } : {}),
+      ...(Number.isFinite(count) ? { count } : {}),
+      ...(params ? { params: { ...params } } : {}),
     });
   }
-};
+}
+
+const level1Waves = [];
 
 pushRepeatingWaves(level1Waves, {
   start: 0,
-  every: 1.2,
-  duration: LEVEL1_DURATION,
+  every: 1.25,
+  until: LEVEL1_DURATION,
   type: 'asteroid',
 });
 
 pushRepeatingWaves(level1Waves, {
-  start: 0.6,
-  every: 2,
-  duration: LEVEL1_DURATION,
+  start: 0.8,
+  every: 2.2,
+  until: LEVEL1_DURATION - 6,
   type: 'strafer',
 });
 
 pushRepeatingWaves(level1Waves, {
-  start: 0.9,
-  every: 2.2,
-  duration: LEVEL1_DURATION,
+  start: 1.2,
+  every: 2.6,
+  until: LEVEL1_DURATION - 8,
   type: 'drone',
 });
 
 pushRepeatingWaves(level1Waves, {
-  start: 1.3,
-  every: 2.6,
-  duration: LEVEL1_DURATION,
+  start: 4,
+  every: 7.5,
+  until: LEVEL1_DURATION - 12,
   type: 'turret',
+  params: { count: 1 },
 });
 
+level1Waves.push(
+  { at: 18, type: 'drone', countRange: [3, 4], params: { vyMin: 70, vyMax: 110 } },
+  { at: 32, type: 'strafer', params: { count: 3 } },
+  { at: 46, type: 'asteroid', params: { countRange: [6, 8], vyMin: 90, vyMax: 150 } },
+  { at: 58, type: 'turret', params: { count: 2, fireCdMin: 900, fireCdMax: 1400 } },
+  { at: 72, type: 'drone', countRange: [4, 5], params: { steerAccel: 34 } },
+);
+
 level1Waves.sort((a, b) => a.at - b.at);
+
+const level2Waves = [];
+
+pushRepeatingWaves(level2Waves, {
+  start: 0,
+  every: 1.1,
+  until: LEVEL2_DURATION - 10,
+  type: 'asteroid',
+  params: { vyMin: 110, vyMax: 170 },
+});
+
+pushRepeatingWaves(level2Waves, {
+  start: 4.5,
+  every: 2,
+  until: LEVEL2_DURATION - 18,
+  type: 'strafer',
+  params: { fireCdMin: 820, fireCdMax: 1260 },
+});
+
+pushRepeatingWaves(level2Waves, {
+  start: 7,
+  every: 3.2,
+  until: LEVEL2_DURATION - 15,
+  type: 'turret',
+  params: { count: 1, fireCdMin: 820, fireCdMax: 1320 },
+});
+
+pushRepeatingWaves(level2Waves, {
+  start: 6.5,
+  every: 2.6,
+  until: LEVEL2_DURATION - 12,
+  type: 'drone',
+  params: { vyMin: 80, vyMax: 130, steerAccel: 44 },
+});
+
+level2Waves.push(
+  { at: 14, type: 'turret', params: { count: 2, bulletSpeed: 220 } },
+  { at: 22, type: 'drone', countRange: [4, 5], params: { steerAccel: 52 } },
+  { at: 30, type: 'strafer', params: { count: 4, speedMin: 170, speedMax: 220 } },
+  { at: 38, type: 'asteroid', params: { countRange: [7, 9], vxMin: -80, vxMax: 80 } },
+  { at: 46, type: 'turret', params: { count: 3, fireCdMin: 740, fireCdMax: 1180 } },
+  { at: 58, type: 'drone', countRange: [5, 6], params: { vyMin: 90, vyMax: 140, steerAccel: 54 } },
+  { at: 70, type: 'strafer', params: { count: 4, fireCdMin: 780, fireCdMax: 1180 } },
+  { at: 82, type: 'turret', params: { count: 2, bulletSpeed: 240, fireCdMin: 720, fireCdMax: 1080 } },
+  { at: 92, type: 'drone', countRange: [6, 7], params: { steerAccel: 60, vyMin: 90, vyMax: 150 } },
+);
+
+level2Waves.sort((a, b) => a.at - b.at);
 
 const level1Boss = {
   kind: 'standard',
@@ -52,11 +116,61 @@ const level1Boss = {
   phases: [0.7, 0.4],
 };
 
+const level2Boss = {
+  kind: 'standard',
+  hp: 440,
+  phases: [0.75, 0.45],
+};
+
 export const LEVELS = [
   {
+    id: 'l1',
     name: 'Asteroid Run',
     duration: LEVEL1_DURATION,
+    theme: 'synth-horizon',
+    modifiers: {
+      spawn: {},
+      enemyWeights: {
+        asteroid: 1,
+        drone: 1,
+        strafer: 1,
+        turret: 1,
+      },
+    },
+    mechanics: {},
     waves: level1Waves,
     boss: level1Boss,
+  },
+  {
+    id: 'l2',
+    name: 'Tempest Drift',
+    duration: LEVEL2_DURATION,
+    theme: 'luminous-depths',
+    modifiers: {
+      spawn: {
+        asteroid: { density: 0.85, vyMin: 110, vyMax: 180 },
+        drone: { density: 1.2, steerAccel: 46, vyMin: 80, vyMax: 140 },
+        strafer: { density: 1.15, fireCdMin: 780, fireCdMax: 1320, speedMin: 160, speedMax: 220 },
+        turret: { density: 1.25, fireCdMin: 760, fireCdMax: 1260, bulletSpeed: 220 },
+      },
+      enemyWeights: {
+        asteroid: 0.95,
+        drone: 1.25,
+        strafer: 1.3,
+        turret: 1.35,
+      },
+    },
+    mechanics: {
+      windX: 36,
+      squallBursts: {
+        interval: [10, 14],
+        duration: 1.2,
+        playerSpread: 90,
+        enemySpread: 18,
+        dimFactor: 0.45,
+      },
+    },
+    waves: level2Waves,
+    boss: level2Boss,
   },
 ];

--- a/src/ui.js
+++ b/src/ui.js
@@ -324,8 +324,8 @@ export function getActiveThemePalette() {
   return getThemePalette(activeThemeKey);
 }
 
-export function setTheme(key) {
-  setThemeInternal(key);
+export function setTheme(key, { persist = true } = {}) {
+  setThemeInternal(key, persist);
 }
 
 export function onThemeChange(handler, { immediate = true } = {}) {


### PR DESCRIPTION
## Summary
- define declarative level data including a new Level 2 with wind and squall mechanics
- update the game loop to schedule levels, unlock progress, and persist the highest unlocked level in localStorage
- refresh the start and summary overlays with continue/select options and styling updates, and apply wind drift to bullets and VFX

## Testing
- node --check src/main.js

------
https://chatgpt.com/codex/tasks/task_e_68e1b7cb38448321ad966e0e089da686