### PR TITLE
Add input manager with keyboard and gamepad support

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -1,0 +1,218 @@
+const KEYBOARD_BINDINGS = {
+  up: ['w', 'arrowup'],
+  down: ['s', 'arrowdown'],
+  left: ['a', 'arrowleft'],
+  right: ['d', 'arrowright'],
+  fire: ['space'],
+  altFire: ['enter'],
+  pause: ['p'],
+  mute: ['m'],
+  fullscreen: ['f'],
+  assist: ['h'],
+  autoFire: ['t'],
+};
+
+const ACTIONS = Object.freeze({
+  PAUSE: 'pause',
+  MUTE: 'mute',
+  FULLSCREEN: 'fullscreen',
+  ASSIST: 'assist',
+  AUTO_FIRE: 'auto-fire',
+});
+
+const keyboardState = new Set();
+const keyToActions = new Map();
+const actionListeners = new Map();
+let lastGamepadConnected = false;
+
+const DEADZONE = 0.22;
+
+function normalizeKey(key) {
+  if (!key) {
+    return '';
+  }
+  if (key === ' ') {
+    return 'space';
+  }
+  const lower = key.toLowerCase();
+  if (lower === 'spacebar') {
+    return 'space';
+  }
+  return lower;
+}
+
+function registerActionKey(keys, action) {
+  for (const key of keys) {
+    const normalized = normalizeKey(key);
+    if (!keyToActions.has(normalized)) {
+      keyToActions.set(normalized, new Set());
+    }
+    keyToActions.get(normalized).add(action);
+  }
+}
+
+registerActionKey(KEYBOARD_BINDINGS.pause, ACTIONS.PAUSE);
+registerActionKey(KEYBOARD_BINDINGS.mute, ACTIONS.MUTE);
+registerActionKey(KEYBOARD_BINDINGS.fullscreen, ACTIONS.FULLSCREEN);
+registerActionKey(KEYBOARD_BINDINGS.assist, ACTIONS.ASSIST);
+registerActionKey(KEYBOARD_BINDINGS.autoFire, ACTIONS.AUTO_FIRE);
+
+function emitAction(action) {
+  const listeners = actionListeners.get(action);
+  if (!listeners) {
+    return;
+  }
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch (err) {
+      // Swallow listener errors to avoid breaking input loop.
+      console.error(err); // eslint-disable-line no-console
+    }
+  }
+}
+
+function handleKeyDown(event) {
+  const key = normalizeKey(event.key);
+  if (!key) {
+    return;
+  }
+  if (['arrowup', 'arrowdown', 'arrowleft', 'arrowright', 'space'].includes(key)) {
+    event.preventDefault();
+  }
+  const isRepeat = event.repeat;
+  keyboardState.add(key);
+  if (!isRepeat) {
+    const mapped = keyToActions.get(key);
+    if (mapped) {
+      for (const action of mapped) {
+        emitAction(action);
+      }
+    }
+  }
+}
+
+function handleKeyUp(event) {
+  const key = normalizeKey(event.key);
+  if (!key) {
+    return;
+  }
+  keyboardState.delete(key);
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('keydown', handleKeyDown, { passive: false });
+  window.addEventListener('keyup', handleKeyUp);
+  window.addEventListener('gamepadconnected', () => {
+    lastGamepadConnected = true;
+  });
+  window.addEventListener('gamepaddisconnected', () => {
+    lastGamepadConnected = false;
+  });
+}
+
+function applyDeadzone(value) {
+  if (Math.abs(value) < DEADZONE) {
+    return 0;
+  }
+  const sign = Math.sign(value);
+  const magnitude = (Math.abs(value) - DEADZONE) / (1 - DEADZONE);
+  return Math.max(0, Math.min(1, magnitude)) * sign;
+}
+
+function pollGamepad() {
+  const pads = typeof navigator !== 'undefined' && navigator.getGamepads ? navigator.getGamepads() : [];
+  if (!pads) {
+    lastGamepadConnected = false;
+    return { connected: false, moveX: 0, moveY: 0, fire: false, altFire: false };
+  }
+  for (const pad of pads) {
+    if (!pad || !pad.connected) {
+      continue;
+    }
+    const axes = Array.isArray(pad.axes) ? pad.axes : [];
+    const buttons = Array.isArray(pad.buttons) ? pad.buttons : [];
+    const leftX = applyDeadzone(axes[0] ?? 0);
+    const leftY = applyDeadzone(axes[1] ?? 0);
+    let moveX = leftX;
+    let moveY = leftY;
+    if (buttons[14]?.pressed) {
+      moveX -= 1;
+    }
+    if (buttons[15]?.pressed) {
+      moveX += 1;
+    }
+    if (buttons[12]?.pressed) {
+      moveY -= 1;
+    }
+    if (buttons[13]?.pressed) {
+      moveY += 1;
+    }
+    moveX = Math.max(-1, Math.min(1, moveX));
+    moveY = Math.max(-1, Math.min(1, moveY));
+    const fire = Boolean(buttons[0]?.pressed);
+    lastGamepadConnected = true;
+    return {
+      connected: true,
+      moveX,
+      moveY,
+      fire,
+      altFire: Boolean(buttons[1]?.pressed),
+    };
+  }
+  lastGamepadConnected = false;
+  return { connected: false, moveX: 0, moveY: 0, fire: false, altFire: false };
+}
+
+function keyActive(binding) {
+  return binding.some((key) => keyboardState.has(key));
+}
+
+function combineAxis(keyboardValue, gamepadValue) {
+  if (Math.abs(gamepadValue) > Math.abs(keyboardValue)) {
+    return gamepadValue;
+  }
+  return keyboardValue;
+}
+
+export function getState() {
+  const keyboardMoveX = (keyActive(KEYBOARD_BINDINGS.left) ? -1 : 0) + (keyActive(KEYBOARD_BINDINGS.right) ? 1 : 0);
+  const keyboardMoveY = (keyActive(KEYBOARD_BINDINGS.up) ? -1 : 0) + (keyActive(KEYBOARD_BINDINGS.down) ? 1 : 0);
+  const keyboardFire = keyActive(KEYBOARD_BINDINGS.fire);
+  const keyboardAltFire = keyActive(KEYBOARD_BINDINGS.altFire);
+
+  const gamepad = pollGamepad();
+
+  return {
+    moveX: combineAxis(keyboardMoveX, gamepad.moveX),
+    moveY: combineAxis(keyboardMoveY, gamepad.moveY),
+    fire: keyboardFire || gamepad.fire,
+    altFire: keyboardAltFire || gamepad.altFire,
+    gamepad: { connected: gamepad.connected || lastGamepadConnected },
+  };
+}
+
+export function onAction(action, listener) {
+  if (!actionListeners.has(action)) {
+    actionListeners.set(action, new Set());
+  }
+  actionListeners.get(action).add(listener);
+  return () => offAction(action, listener);
+}
+
+export function offAction(action, listener) {
+  const listeners = actionListeners.get(action);
+  if (!listeners) {
+    return;
+  }
+  listeners.delete(listener);
+  if (listeners.size === 0) {
+    actionListeners.delete(action);
+  }
+}
+
+export function clearInput() {
+  keyboardState.clear();
+}
+
+export { ACTIONS };

--- a/src/player.js
+++ b/src/player.js
@@ -23,14 +23,12 @@ export function resetPlayer(state) {
   state.player = createPlayer();
 }
 
-export function updatePlayer(player, keys, dt, hasBoost) {
+export function updatePlayer(player, input, dt, hasBoost) {
   const accel = hasBoost ? 560 : 380;
-  const up = keys.has('arrowup') || keys.has('w');
-  const down = keys.has('arrowdown') || keys.has('s');
-  const left = keys.has('arrowleft') || keys.has('a');
-  const right = keys.has('arrowright') || keys.has('d');
-  const ax = (left ? -accel : 0) + (right ? accel : 0);
-  const ay = (up ? -accel * 0.8 : 0) + (down ? accel * 0.8 : 0);
+  const moveX = clamp(Number.isFinite(input?.moveX) ? input.moveX : 0, -1, 1);
+  const moveY = clamp(Number.isFinite(input?.moveY) ? input.moveY : 0, -1, 1);
+  const ax = moveX * accel;
+  const ay = moveY * accel * 0.8;
   player.vx = lerp(player.vx, ax, 0.08);
   player.vy = lerp(player.vy, ay, 0.08);
   player.x += player.vx * dt;
@@ -43,16 +41,11 @@ export function clampPlayerToBounds(player) {
   player.y = clamp(player.y, 40, Math.max(h - 40, 40));
 }
 
-export function drawPlayer(ctx, player, keys, palette, weaponFlash = null) {
+export function drawPlayer(ctx, player, input, palette, weaponFlash = null) {
   const ship = resolvePaletteSection(palette, 'ship');
   ctx.save();
   ctx.translate(player.x, player.y);
-  const tilt = clamp(
-    (keys.has('arrowleft') || keys.has('a') ? -1 : 0) +
-      (keys.has('arrowright') || keys.has('d') ? 1 : 0),
-    -1,
-    1,
-  );
+  const tilt = clamp(Number.isFinite(input?.moveX) ? input.moveX : 0, -1, 1);
   ctx.rotate(tilt * 0.08);
 
   const engLen = 14 + (Math.sin(performance.now() * 0.02) + 1) * 6;

--- a/src/ui.js
+++ b/src/ui.js
@@ -60,6 +60,7 @@ const hudPowerChip = document.getElementById('power-chip');
 const hudWeaponChip = document.getElementById('weapon-chip');
 const hudWeaponIcon = document.getElementById('weapon-icon');
 let autoFirePill = document.getElementById('auto-fire-pill');
+let gamepadPill = document.getElementById('gamepad-pill');
 
 const THEME_STORAGE_KEY = 'retro-space-run.theme';
 const ASSIST_STORAGE_KEY = 'retro-space-run.assist';
@@ -220,6 +221,18 @@ function injectHudStyles() {
       background: #ffffff12;
       opacity: 1;
     }
+    #hud .pill.pill--gamepad {
+      font-size: 0.7rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      padding: 0.2rem 0.6rem;
+      opacity: 0.72;
+    }
+    #hud .pill.pill--gamepad.is-active {
+      opacity: 1;
+      background: #ffffff12;
+      box-shadow: 0 0 8px #00e5ff33 inset, 0 0 12px #00e5ff1f;
+    }
     #hud .pill.pill--theme {
       display: inline-flex;
       align-items: center;
@@ -305,6 +318,14 @@ function setupHudLayout(root) {
       <div class="hud-secondary-group">
         <button id="assist-toggle" class="pill" type="button" aria-pressed="false">Assist: Off</button>
         <span id="auto-fire-pill" class="pill pill--auto" role="status" aria-live="polite">Auto: Off</span>
+        <span
+          id="gamepad-pill"
+          class="pill pill--gamepad"
+          role="status"
+          aria-live="polite"
+          aria-hidden="true"
+          hidden
+        >Gamepad: Connected</span>
         <span class="pill pill--theme">
           <span class="hud-title">Theme</span>
           <select id="theme-select" class="hud-theme" aria-label="Theme selection"></select>
@@ -447,6 +468,19 @@ function syncAutoFirePill() {
   autoFirePill.textContent = `Auto: ${autoFire ? 'On' : 'Off'}`;
   autoFirePill.setAttribute('aria-label', `Auto-fire ${autoFire ? 'on' : 'off'}`);
   autoFirePill.classList.toggle('is-on', autoFire);
+}
+
+export function setGamepadIndicator(connected) {
+  if (!gamepadPill) {
+    gamepadPill = document.getElementById('gamepad-pill');
+    if (!gamepadPill) {
+      return;
+    }
+  }
+  const isConnected = Boolean(connected);
+  gamepadPill.hidden = !isConnected;
+  gamepadPill.setAttribute('aria-hidden', isConnected ? 'false' : 'true');
+  gamepadPill.classList.toggle('is-active', isConnected);
 }
 
 function emitThemeChange() {

--- a/src/weapons.js
+++ b/src/weapons.js
@@ -737,7 +737,7 @@ function spawnProjectile(state, projectile, levelIndex) {
   pushMuzzleFlash(state, projectile, levelIndex, width, height, colour, vx, vy);
 }
 
-export function handlePlayerShooting(state, keys, now) {
+export function handlePlayerShooting(state, input, now) {
   ensureWeaponState(state);
   const level = currentLevel(state);
   if (!level) {
@@ -747,7 +747,7 @@ export function handlePlayerShooting(state, keys, now) {
   const levelIndex = def ? clampLevel(def, state.weapon.level) : 0;
   const rapid = state.power.name === 'rapid';
   const delay = Math.max(70, level.delay * (rapid ? 0.6 : 1));
-  if ((keys.has(' ') || keys.has('space')) && now - state.lastShot > delay) {
+  if (input?.fire && now - state.lastShot > delay) {
     state.lastShot = now;
     for (const projectile of level.projectiles) {
       spawnProjectile(state, projectile, levelIndex);


### PR DESCRIPTION
## Summary
- add a reusable input module that maps keyboard controls and polls gamepads
- update the main loop and gameplay helpers to consume the new input state
- surface a HUD indicator that lights up when a controller is connected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e25405ac6c8321b69441463da6cae5