### PR TITLE
Add screen shake, explosions, and toast feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
   #hud .pill.pill--theme{gap:.6rem;}
   #hud button.pill:focus-visible{outline:2px solid var(--cyn); outline-offset:2px;}
   #hud button.pill.is-on{box-shadow:0 0 8px #00e5ff55 inset, 0 0 8px #ff3df755; background:#ffffff10;}
-  #upgrade-banner{
+  #game-toast{
     position:fixed; top:74px; left:50%; transform:translate(-50%,-24px);
     font-size:1rem; font-weight:700; letter-spacing:.18em; text-transform:uppercase;
     color:var(--white); text-shadow:0 0 12px #ff3df7aa, 0 0 16px #00e5ff99;
@@ -42,8 +42,8 @@
     padding:.45rem 1.2rem; border:1px solid #ffffff33; border-radius:999px;
     background:#0a0d1acc; box-shadow:0 0 18px #00e5ff33;
   }
-  #upgrade-banner.is-visible{animation:upgradeFlash 1.2s ease-out forwards;}
-  @keyframes upgradeFlash{
+  #game-toast.is-visible{animation:toastFlash var(--toast-duration, 1.2s) ease-out forwards;}
+  @keyframes toastFlash{
     0%{opacity:0; transform:translate(-50%,-24px) scale(.92);}
     15%{opacity:1; transform:translate(-50%,0) scale(1);}
     75%{opacity:1;}
@@ -107,7 +107,7 @@
   </span>
 </div>
 
-<div id="upgrade-banner" aria-hidden="true"></div>
+<div id="game-toast" role="status" aria-live="polite" aria-atomic="true"></div>
 
 <div id="msg">
   <div class="box" id="overlay">

--- a/src/audio.js
+++ b/src/audio.js
@@ -5,6 +5,25 @@ let audioOn = true;
 let ac;
 let master;
 
+const SFX_PRESETS = {
+  hit: [
+    { type: 'triangle', freq: 200, len: 0.22, gain: 0.32 },
+    { type: 'sine', freq: 420, len: 0.08, gain: 0.18, delay: 0.02 },
+  ],
+  explode: [
+    { type: 'square', freq: 160, len: 0.32, gain: 0.35 },
+    { type: 'sawtooth', freq: 90, len: 0.46, gain: 0.26, delay: 0.04 },
+  ],
+  upgrade: [
+    { type: 'triangle', freq: 780, len: 0.24, gain: 0.26 },
+    { type: 'square', freq: 520, len: 0.18, gain: 0.18, delay: 0.04 },
+  ],
+  bossDown: [
+    { type: 'sawtooth', freq: 260, len: 0.5, gain: 0.32 },
+    { type: 'triangle', freq: 140, len: 0.64, gain: 0.28, delay: 0.06 },
+  ],
+};
+
 function ensureAudio() {
   if (ac) {
     return;
@@ -20,7 +39,7 @@ function ensureAudio() {
   master.connect(ac.destination);
 }
 
-function playTone(type, freq, len, gain) {
+function playTone(type, freq, len, gain, delay = 0) {
   if (!audioOn) {
     return;
   }
@@ -30,15 +49,31 @@ function playTone(type, freq, len, gain) {
   }
   const osc = ac.createOscillator();
   const g = ac.createGain();
+  const duration = Math.max(0.02, len);
+  const startDelay = Math.max(0, delay);
+  const t = ac.currentTime + startDelay;
   osc.type = type;
-  osc.frequency.value = freq;
-  g.gain.value = gain;
+  osc.frequency.setValueAtTime(freq, t);
+  g.gain.value = Math.max(0, gain);
   osc.connect(g);
   g.connect(master);
-  const t = ac.currentTime;
   osc.start(t);
-  g.gain.exponentialRampToValueAtTime(0.0001, t + len);
-  osc.stop(t + len + 0.02);
+  g.gain.setValueAtTime(Math.max(0.0001, gain), t);
+  g.gain.exponentialRampToValueAtTime(0.0001, t + duration);
+  osc.stop(t + duration + 0.05);
+}
+
+export function playSfx(id) {
+  if (!audioOn) {
+    return;
+  }
+  const preset = SFX_PRESETS[id];
+  if (!preset) {
+    return;
+  }
+  for (const tone of preset) {
+    playTone(tone.type, tone.freq, tone.len, tone.gain, tone.delay ?? 0);
+  }
 }
 
 export function playZap() {
@@ -50,16 +85,19 @@ export function playPew() {
 }
 
 export function playHit() {
-  playTone('triangle', 180, 0.2, 0.35);
+  playSfx('hit');
 }
 
 export function playPow() {
-  playTone('sine', 560, 0.25, 0.28);
+  playSfx('explode');
 }
 
 export function playUpgrade() {
-  playTone('triangle', 760, 0.18, 0.28);
-  playTone('square', 520, 0.12, 0.18);
+  playSfx('upgrade');
+}
+
+export function playBossDown() {
+  playSfx('bossDown');
 }
 
 export function toggleAudio() {

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,0 +1,176 @@
+/**
+ * effects.js — lightweight screen shake, explosions, and toast feedback helpers.
+ */
+import { rand, addParticle } from './utils.js';
+import { DEFAULT_THEME_PALETTE, resolvePaletteSection } from './themes.js';
+
+const shakeState = {
+  time: 0,
+  duration: 0,
+  magnitude: 0,
+  offsetX: 0,
+  offsetY: 0,
+};
+
+const pendingExplosions = [];
+let lastStateRef = null;
+
+const EXPLOSION_PRESETS = {
+  small: [
+    { key: 'enemyHitDefault', count: 22, spread: 2.8, life: 360 },
+    { key: 'enemyHitStrafer', count: 12, spread: 2.2, life: 280 },
+  ],
+  boss: [
+    { key: 'bossHit', count: 80, spread: 5.4, life: 1100 },
+    { key: 'bossCore', count: 52, spread: 4.6, life: 960 },
+    { key: 'enemyHitDefault', count: 36, spread: 3.8, life: 840 },
+  ],
+};
+
+const TOAST_ID = 'game-toast';
+let toastEl = null;
+let toastTimeout = null;
+
+function ensureToastElement() {
+  if (toastEl) {
+    return toastEl;
+  }
+  toastEl = document.getElementById(TOAST_ID);
+  if (!toastEl) {
+    toastEl = document.createElement('div');
+    toastEl.id = TOAST_ID;
+    toastEl.setAttribute('role', 'status');
+    toastEl.setAttribute('aria-live', 'polite');
+    toastEl.setAttribute('aria-atomic', 'true');
+    toastEl.className = 'game-toast';
+    document.body.appendChild(toastEl);
+  }
+  return toastEl;
+}
+
+function resolveExplosionPreset(kind) {
+  if (Array.isArray(kind)) {
+    return kind;
+  }
+  if (EXPLOSION_PRESETS[kind]) {
+    return EXPLOSION_PRESETS[kind];
+  }
+  return EXPLOSION_PRESETS.small;
+}
+
+export function shakeScreen(magnitude = 3, duration = 200) {
+  const mag = Math.max(0, Number(magnitude) || 0);
+  const dur = Math.max(0, Number(duration) || 0);
+  if (dur <= 0 || mag <= 0) {
+    return;
+  }
+  shakeState.time = Math.max(shakeState.time, dur);
+  shakeState.duration = Math.max(shakeState.duration, dur);
+  shakeState.magnitude = Math.max(shakeState.magnitude, mag);
+}
+
+function updateScreenShake(dt) {
+  if (shakeState.time <= 0) {
+    shakeState.time = 0;
+    shakeState.duration = 0;
+    shakeState.magnitude = 0;
+    shakeState.offsetX = 0;
+    shakeState.offsetY = 0;
+    return;
+  }
+  shakeState.time = Math.max(0, shakeState.time - dt * 1000);
+  const progress = shakeState.duration > 0 ? shakeState.time / shakeState.duration : 0;
+  const strength = shakeState.magnitude * progress * progress;
+  if (strength > 0.05) {
+    shakeState.offsetX = rand(-strength, strength);
+    shakeState.offsetY = rand(-strength, strength);
+  } else {
+    shakeState.offsetX = 0;
+    shakeState.offsetY = 0;
+  }
+  if (shakeState.time <= 0) {
+    shakeState.duration = 0;
+    shakeState.magnitude = 0;
+  }
+}
+
+function flushExplosions(state) {
+  if (!state || pendingExplosions.length === 0) {
+    return;
+  }
+  const palette = resolvePaletteSection(state.theme ?? DEFAULT_THEME_PALETTE, 'particles');
+  const fallbackColour = palette.enemyHitDefault || palette.playerHit || '#ffffff';
+  while (pendingExplosions.length) {
+    const { x, y, preset } = pendingExplosions.shift();
+    for (const burst of preset) {
+      const colour = palette[burst.key] || fallbackColour;
+      addParticle(state, x, y, colour, burst.count, burst.spread, burst.life);
+    }
+  }
+}
+
+export function updateEffects(state, dt) {
+  const clampedDt = Math.max(0, Number(dt) || 0);
+  lastStateRef = state || lastStateRef;
+  updateScreenShake(clampedDt);
+  flushExplosions(state);
+}
+
+export function getScreenShakeOffset() {
+  return shakeState;
+}
+
+export function resetEffects() {
+  shakeState.time = 0;
+  shakeState.duration = 0;
+  shakeState.magnitude = 0;
+  shakeState.offsetX = 0;
+  shakeState.offsetY = 0;
+  pendingExplosions.length = 0;
+  lastStateRef = null;
+  hideToast();
+}
+
+export function spawnExplosion(x, y, kind = 'small') {
+  const preset = resolveExplosionPreset(kind);
+  if (!preset || !preset.length) {
+    return;
+  }
+  pendingExplosions.push({ x, y, preset });
+  if (lastStateRef) {
+    flushExplosions(lastStateRef);
+  }
+}
+
+export function showToast(text, duration = 1200) {
+  const message = typeof text === 'string' ? text.trim() : '';
+  if (!message) {
+    return;
+  }
+  const el = ensureToastElement();
+  const ms = Math.max(600, Number(duration) || 0);
+  el.textContent = message;
+  el.style.setProperty('--toast-duration', `${ms}ms`);
+  el.classList.remove('is-visible');
+  // Force reflow so animation restarts consistently.
+  void el.offsetWidth; // eslint-disable-line no-unused-expressions
+  el.classList.add('is-visible');
+  if (toastTimeout) {
+    window.clearTimeout(toastTimeout);
+  }
+  toastTimeout = window.setTimeout(() => {
+    el.classList.remove('is-visible');
+    toastTimeout = null;
+  }, ms);
+}
+
+export function hideToast() {
+  if (!toastEl) {
+    return;
+  }
+  toastEl.classList.remove('is-visible');
+  if (toastTimeout) {
+    window.clearTimeout(toastTimeout);
+    toastTimeout = null;
+  }
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -51,7 +51,6 @@ const hudLevel = document.getElementById('level-chip');
 const overlay = document.getElementById('overlay');
 const themeSelect = document.getElementById('theme-select');
 const assistToggle = document.getElementById('assist-toggle');
-const upgradeBanner = document.getElementById('upgrade-banner');
 const hudLivesChip = document.getElementById('hud-lives-chip');
 const hudShieldMeter = document.getElementById('shield-meter');
 const hudShieldFill = document.getElementById('shield-fill');
@@ -69,7 +68,6 @@ const AUTO_FIRE_STORAGE_KEY = 'retro-space-run.auto-fire';
 const themeListeners = new Set();
 const assistListeners = new Set();
 const autoFireListeners = new Set();
-let upgradeBannerTimeout = null;
 
 function injectHudStyles() {
   if (typeof document === 'undefined' || document.getElementById(HUD_STYLE_ID)) {
@@ -755,31 +753,9 @@ export function updateLevelChip({ levelIndex, name, mutators } = {}) {
   hudLevel.setAttribute('aria-label', `Level status: ${label}`);
 }
 
-function showUpgradeBanner(name, level) {
-  if (!upgradeBanner) {
-    return;
-  }
-  const cleanName = name?.trim();
-  const cleanLevel = level?.trim();
-  if (!cleanName || !cleanLevel) {
-    return;
-  }
-  const message = `UPGRADE: ${cleanName} · ${cleanLevel}`;
-  upgradeBanner.textContent = message;
-  upgradeBanner.classList.remove('is-visible');
-  void upgradeBanner.offsetWidth;
-  upgradeBanner.classList.add('is-visible');
-  if (upgradeBannerTimeout) {
-    window.clearTimeout(upgradeBannerTimeout);
-  }
-  upgradeBannerTimeout = window.setTimeout(() => {
-    upgradeBanner.classList.remove('is-visible');
-  }, 1200);
-}
-
 export function updateWeapon(
   label,
-  { flash = false, upgradeName, upgradeLevel, icon } = {},
+  { icon } = {},
 ) {
   const resolved = normalizeWeaponLabel(label);
   if (hudWeapon) {
@@ -793,12 +769,6 @@ export function updateWeapon(
     hudWeaponChip.setAttribute('title', descriptor);
     hudWeaponChip.setAttribute('aria-label', descriptor);
   }
-  if (!flash) {
-    return;
-  }
-  const hudName = upgradeName || resolved.name || null;
-  const hudLevel = upgradeLevel || resolved.level || null;
-  showUpgradeBanner(hudName, hudLevel);
 }
 
 export function currentOverlay() {


### PR DESCRIPTION
## Summary
- add a shared effects module that handles screen shake, explosion particle presets, and top-centre toast messaging
- trigger the new explosions, shake, toast, and upgraded audio cues on enemy and boss kills as well as weapon upgrades
- refresh HUD toast styling and expand the synthesised SFX palette to cover hit, explode, upgrade, and boss-down events

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e25846fa64832181010004e195394c