### PR TITLE
Show damage window cues and precision indicator

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -10,6 +10,7 @@ const KEYBOARD_BINDINGS = {
   fullscreen: ['f'],
   assist: ['h'],
   autoFire: ['t'],
+  precision: ['shift'],
 };
 
 const ACTIONS = Object.freeze({
@@ -188,6 +189,7 @@ export function getState() {
     moveY: combineAxis(keyboardMoveY, gamepad.moveY),
     fire: keyboardFire || gamepad.fire,
     altFire: keyboardAltFire || gamepad.altFire,
+    precision: keyActive(KEYBOARD_BINDINGS.precision),
     gamepad: { connected: gamepad.connected || lastGamepadConnected },
   };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -63,7 +63,16 @@ import { LEVELS } from './levels.js';
 import { getDifficulty } from './difficulty.js';
 import { updateBullets, freeBullet, drainBullets } from './bullets.js';
 import { getState as getInputState, onAction as onInputAction, clearInput, ACTIONS as INPUT_ACTIONS } from './input.js';
-import { shakeScreen, updateEffects, getScreenShakeOffset, resetEffects, spawnExplosion, showToast } from './effects.js';
+import {
+  shakeScreen,
+  updateEffects,
+  getScreenShakeOffset,
+  resetEffects,
+  spawnExplosion,
+  showToast,
+  triggerDamagePulse,
+  drawDamagePulse,
+} from './effects.js';
 
 let activePalette = getActiveThemePalette() ?? DEFAULT_THEME_PALETTE;
 
@@ -769,6 +778,7 @@ function handlePlayerHit() {
   }
   state.lives -= 1;
   updateLives(state.lives);
+  triggerDamagePulse(state.lives <= 1 ? 0.85 : 0.55);
   addParticle(state, player.x, player.y, particles.playerHit, 30, 3.2, 500);
   playZap();
   state.bossMercyUntil = performance.now() + 600;
@@ -1025,6 +1035,7 @@ function loop(now) {
     drawGate(state.finishGate, palette);
   }
   drawPlayer(ctx, player, inputState, palette, state.weaponPickupFlash);
+  drawDamagePulse(ctx, viewW, viewH);
 
   if (state.boss) {
     drawBossHealth(ctx, state.boss, palette);


### PR DESCRIPTION
## Summary
- add a keyboard precision toggle and draw a cyan hitbox dot while held
- flicker the ship and render a protective ring during invulnerability frames
- pulse a red vignette overlay after taking damage to highlight low-life states

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e25cd34c408321ab2a741353949f41