### PR TITLE
Add restart hotkey and reset flow improvements

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -10,6 +10,7 @@ const KEYBOARD_BINDINGS = {
   fullscreen: ['f'],
   assist: ['h'],
   autoFire: ['t'],
+  restart: ['r'],
   precision: ['shift'],
 };
 
@@ -19,6 +20,7 @@ const ACTIONS = Object.freeze({
   FULLSCREEN: 'fullscreen',
   ASSIST: 'assist',
   AUTO_FIRE: 'auto-fire',
+  RESTART: 'restart',
 });
 
 const keyboardState = new Set();
@@ -57,6 +59,7 @@ registerActionKey(KEYBOARD_BINDINGS.mute, ACTIONS.MUTE);
 registerActionKey(KEYBOARD_BINDINGS.fullscreen, ACTIONS.FULLSCREEN);
 registerActionKey(KEYBOARD_BINDINGS.assist, ACTIONS.ASSIST);
 registerActionKey(KEYBOARD_BINDINGS.autoFire, ACTIONS.AUTO_FIRE);
+registerActionKey(KEYBOARD_BINDINGS.restart, ACTIONS.RESTART);
 
 function emitAction(action) {
   const listeners = actionListeners.get(action);

--- a/src/ui.js
+++ b/src/ui.js
@@ -40,17 +40,8 @@ export const canvas = document.getElementById('game');
 export const ctx = canvas.getContext('2d');
 
 const hudRoot = document.getElementById('hud');
-
-injectHudStyles();
-setupHudLayout(hudRoot);
-bindDifficultySelect();
-subscribeDifficultyMode((mode) => {
-  syncDifficultySelect(mode);
-});
-
-let DPR = window.devicePixelRatio || 1;
-let VIEW_W = window.innerWidth || canvas.clientWidth || canvas.width || 0;
-let VIEW_H = window.innerHeight || canvas.clientHeight || canvas.height || 0;
+const overlay = document.getElementById('overlay');
+let difficultySelect = document.getElementById('difficulty-select');
 
 const hudLives = document.getElementById('lives');
 const hudScore = document.getElementById('score');
@@ -58,10 +49,8 @@ const hudTime = document.getElementById('time');
 const hudPower = document.getElementById('pup');
 const hudWeapon = document.getElementById('weapon');
 const hudLevel = document.getElementById('level-chip');
-const overlay = document.getElementById('overlay');
 const themeSelect = document.getElementById('theme-select');
 const assistToggle = document.getElementById('assist-toggle');
-let difficultySelect = document.getElementById('difficulty-select');
 const hudLivesChip = document.getElementById('hud-lives-chip');
 const hudShieldMeter = document.getElementById('shield-meter');
 const hudShieldFill = document.getElementById('shield-fill');
@@ -80,6 +69,17 @@ const themeListeners = new Set();
 const assistListeners = new Set();
 const autoFireListeners = new Set();
 const DIFFICULTY_KEYS = new Set(Object.keys(DIFFICULTY));
+
+injectHudStyles();
+setupHudLayout(hudRoot);
+bindDifficultySelect();
+subscribeDifficultyMode((mode) => {
+  syncDifficultySelect(mode);
+});
+
+let DPR = window.devicePixelRatio || 1;
+let VIEW_W = window.innerWidth || canvas.clientWidth || canvas.width || 0;
+let VIEW_H = window.innerHeight || canvas.clientHeight || canvas.height || 0;
 
 function syncDifficultySelect(mode = getStoredDifficultyMode()) {
   if (!difficultySelect) {
@@ -707,6 +707,10 @@ export function showOverlay(html) {
   overlay.style.display = 'block';
   bindStartButton();
   bindDifficultySelect();
+  const focusTarget = overlay.querySelector('[autofocus], .btn, button, [role="button"]');
+  if (focusTarget?.focus) {
+    focusTarget.focus();
+  }
 }
 
 export function hideOverlay() {


### PR DESCRIPTION
## Summary
- add an R hotkey that pauses the run, shows a confirmation overlay, and funnels through a new resetGame helper that clears bullets, timers, powerups, effects, and weapon state before reloading the level
- update win and game-over overlays so Restart is the primary autofocused action with Menu as the secondary option, and ensure overlay rendering focuses the default button
- fix the UI bootstrap order for difficulty controls to avoid temporal dead zone errors when overlays re-bind select elements

## Testing
- npm run lint *(fails: repository has no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e263b675348321a04aa958bfcdae45