### PR TITLE
Add wind drift and squall telegraphing effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
   #hud .level-chip__icon--wind-right{animation:levelChipWindRight 1.8s ease-in-out infinite;}
   #hud .level-chip__icon--wind-left{animation:levelChipWindLeft 1.8s ease-in-out infinite;}
   #hud .level-chip__icon--squall{animation:levelChipSquall 2.6s linear infinite;}
+  #hud .level-chip__icon--squall.level-chip__icon--squall-burst{animation:levelChipSquall 2.6s linear infinite, levelChipSquallBurst 0.65s ease-out;}
   #hud .hud-label{position:relative; display:inline-flex; align-items:center; font-size:.75rem; text-transform:uppercase; letter-spacing:.08em; opacity:.78; min-width:5.1rem; justify-content:flex-end;}
   #hud .hud-label::after{content:':'; margin-left:.35rem; opacity:.6; font-size:.8rem; letter-spacing:0;}
   #hud .hud-value{font-weight:700; font-variant-numeric:tabular-nums; letter-spacing:.02em;}
@@ -100,6 +101,7 @@
   @keyframes levelChipWindRight{0%{transform:translateX(0)}50%{transform:translateX(4px)}100%{transform:translateX(0)}}
   @keyframes levelChipWindLeft{0%{transform:translateX(0)}50%{transform:translateX(-4px)}100%{transform:translateX(0)}}
   @keyframes levelChipSquall{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+  @keyframes levelChipSquallBurst{0%{transform:scale(1) rotate(0deg)}35%{transform:scale(1.35) rotate(80deg)}100%{transform:scale(1) rotate(360deg)}}
 </style>
 </head>
 <body>

--- a/src/enemies.js
+++ b/src/enemies.js
@@ -41,7 +41,10 @@ function enemySquallSpread(state, scale = 1) {
     return 0;
   }
   const factor = Number.isFinite(scale) ? Math.max(0, scale) : 1;
-  return rand(-spread * factor, spread * factor);
+  const multiplier = Number.isFinite(squall.enemySpreadMultiplier)
+    ? Math.max(1, squall.enemySpreadMultiplier)
+    : 1.3;
+  return rand(-spread * factor * multiplier, spread * factor * multiplier);
 }
 
 function resolveSpawnCount(baseCount, assistEnabled) {

--- a/src/player.js
+++ b/src/player.js
@@ -23,7 +23,7 @@ export function resetPlayer(state) {
   state.player = createPlayer();
 }
 
-export function updatePlayer(player, input, dt, hasBoost) {
+export function updatePlayer(player, input, dt, hasBoost, windX = 0) {
   const accel = hasBoost ? 560 : 380;
   const moveX = clamp(Number.isFinite(input?.moveX) ? input.moveX : 0, -1, 1);
   const moveY = clamp(Number.isFinite(input?.moveY) ? input.moveY : 0, -1, 1);
@@ -31,7 +31,8 @@ export function updatePlayer(player, input, dt, hasBoost) {
   const ay = moveY * accel * 0.8;
   player.vx = lerp(player.vx, ax, 0.08);
   player.vy = lerp(player.vy, ay, 0.08);
-  player.x += player.vx * dt;
+  const drift = clamp(Number.isFinite(windX) ? windX : 0, -80, 80);
+  player.x += (player.vx + drift) * dt;
   player.y += player.vy * dt;
 }
 


### PR DESCRIPTION
## Summary
- add wind drift drift to player movement, projectiles, and a subtle parallax wind streak layer that reacts to level mutators
- enhance squall events with hatch overlays, dimmer stars, toast messaging, and HUD icon pulses sourced from level mutator definitions
- widen enemy projectile spreads during squalls and expose HUD mutator pulsing helpers for weather feedback

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e2723490388321bd75f62cf8a54785