### PR TITLE
Add combo score multiplier system

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
   </span>
   <span class="pill"><span class="hud-label">Lives</span><span id="lives" class="hud-value">3</span></span>
   <span class="pill"><span class="hud-label">Score</span><span id="score" class="hud-value">0</span></span>
+  <span class="pill"><span class="hud-label">Multiplier</span><span id="combo" class="hud-value">x1.0</span></span>
   <span class="pill"><span class="hud-label">Time</span><span id="time" class="hud-value">0s</span></span>
   <span class="pill"><span class="hud-label">Weapon</span><span id="weapon" class="hud-value">None</span></span>
   <span class="pill"><span class="hud-label">Power-up</span><span id="pup" class="hud-value">None</span></span>

--- a/src/weapons.js
+++ b/src/weapons.js
@@ -865,8 +865,12 @@ function upgradeWeapon(state, weaponName) {
     state.weapon.level += 1;
     upgraded = true;
   } else {
-    state.score = (state.score ?? 0) + 500;
-    updateScore(state.score);
+    if (typeof state.addScore === 'function') {
+      state.addScore(500);
+    } else {
+      state.score = (state.score ?? 0) + 500;
+      updateScore(state.score);
+    }
     updateWeaponHud(state);
     state.weaponDropSecured = true;
     playPow();


### PR DESCRIPTION
## Summary
- track combo streak state with decay, incrementing on kills and resetting on hits
- apply the combo-based multiplier to all score awards and reuse it for duplicate weapon bonuses
- add a HUD multiplier chip with a subtle animation and keep fallback markup in sync

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e27fd5c24c83219fc870685471fe16