### PR TITLE
Persist player progress and add options overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,8 @@
   .btn.btn-secondary{background:#ffffff08; border-color:#00e5ff44; box-shadow:0 0 10px #00e5ff22 inset, 0 0 10px #00e5ff22;}
   .btn.btn-secondary:hover{background:#00e5ff12;}
   .overlay-actions{display:flex; flex-wrap:wrap; gap:.75rem; justify-content:center; margin-top:1rem;}
+  .overlay-progress{margin:0.6rem 0 0; font-size:.9rem; letter-spacing:.05em;}
+  .overlay-hint{margin:1.2rem 0 0; font-size:.78rem; opacity:.72; letter-spacing:.08em;}
   .upgrade-grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1rem; margin-top:1.2rem;}
   .upgrade-card{display:flex; flex-direction:column; align-items:flex-start; gap:.55rem; padding:1rem; border:1px solid #00e5ff33; border-radius:14px; background:#0a0d1acc; box-shadow:0 0 12px #00e5ff1c inset; color:var(--white); text-align:left; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease; font:inherit; width:100%;}
   .upgrade-card:hover{transform:translateY(-2px); box-shadow:0 0 18px #00e5ff44 inset,0 0 14px #00e5ff44; border-color:#00e5ff66;}
@@ -100,6 +102,11 @@
   .difficulty-select__control{min-width:220px; padding:.45rem .6rem; border-radius:999px; border:1px solid #00e5ff55; background:#ffffff0f; color:var(--white); font-weight:600; letter-spacing:.04em; text-transform:none; box-shadow:0 0 10px #00e5ff22 inset;}
   .difficulty-select__control:focus-visible{outline:2px solid var(--cyn); outline-offset:2px;}
   .difficulty-select__hint{margin:0; font-size:.75rem; letter-spacing:.04em; opacity:.75; text-align:center; max-width:320px;}
+  .options-section{margin-top:1rem; display:flex; flex-direction:column; gap:.55rem; align-items:center;}
+  .options-section:first-of-type{margin-top:1.2rem;}
+  .options-section__label{margin:0; text-transform:uppercase; letter-spacing:.1em; font-size:.78rem; opacity:.78;}
+  .options-theme{display:flex; flex-wrap:wrap; gap:.5rem; justify-content:center;}
+  #options-volume{width:240px;}
   /* Scanline / vignette */
   #fx{
     position:fixed; inset:0; pointer-events:none; mix-blend-mode:screen;

--- a/src/difficulty.js
+++ b/src/difficulty.js
@@ -8,8 +8,9 @@ export const DIFFICULTY = Object.freeze({
   hard: { density: 1.2, speed: 1.1, hp: 1.1 },
 });
 
+import { getMetaValue, updateStoredMeta } from './storage.js';
+
 const DEFAULT_MODE = 'normal';
-const STORAGE_KEY = 'retro-space-run.difficulty';
 const listeners = new Set();
 
 function normaliseMode(mode) {
@@ -21,31 +22,14 @@ function normaliseMode(mode) {
 }
 
 function readStoredMode() {
-  if (typeof window === 'undefined') {
-    return DEFAULT_MODE;
-  }
-  try {
-    const stored = window.localStorage?.getItem(STORAGE_KEY);
-    if (!stored) {
-      return DEFAULT_MODE;
-    }
-    return normaliseMode(stored);
-  } catch (err) {
-    return DEFAULT_MODE;
-  }
+  const stored = getMetaValue('difficulty', DEFAULT_MODE);
+  return normaliseMode(stored);
 }
 
 let currentMode = readStoredMode();
 
 function persistMode(mode) {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  try {
-    window.localStorage?.setItem(STORAGE_KEY, mode);
-  } catch (err) {
-    /* ignore persistence issues */
-  }
+  updateStoredMeta({ difficulty: mode });
 }
 
 function emitChange(mode) {

--- a/src/input.js
+++ b/src/input.js
@@ -12,6 +12,7 @@ const KEYBOARD_BINDINGS = {
   autoFire: ['t'],
   restart: ['r'],
   precision: ['shift'],
+  options: ['escape'],
 };
 
 const ACTIONS = Object.freeze({
@@ -21,6 +22,7 @@ const ACTIONS = Object.freeze({
   ASSIST: 'assist',
   AUTO_FIRE: 'auto-fire',
   RESTART: 'restart',
+  OPTIONS: 'options',
 });
 
 const keyboardState = new Set();
@@ -60,6 +62,7 @@ registerActionKey(KEYBOARD_BINDINGS.fullscreen, ACTIONS.FULLSCREEN);
 registerActionKey(KEYBOARD_BINDINGS.assist, ACTIONS.ASSIST);
 registerActionKey(KEYBOARD_BINDINGS.autoFire, ACTIONS.AUTO_FIRE);
 registerActionKey(KEYBOARD_BINDINGS.restart, ACTIONS.RESTART);
+registerActionKey(KEYBOARD_BINDINGS.options, ACTIONS.OPTIONS);
 
 function emitAction(action) {
   const listeners = actionListeners.get(action);

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,111 @@
+const STORAGE_KEY = 'retro-space-run.meta';
+
+const DEFAULT_META = Object.freeze({
+  highestUnlockedLevel: 1,
+  bestScore: 0,
+  preferredTheme: null,
+  difficulty: 'normal',
+  assist: false,
+});
+
+let cachedMeta = null;
+
+function readRawMeta() {
+  if (cachedMeta) {
+    return cachedMeta;
+  }
+  if (typeof window === 'undefined') {
+    cachedMeta = { ...DEFAULT_META };
+    return cachedMeta;
+  }
+  try {
+    const stored = window.localStorage?.getItem(STORAGE_KEY);
+    if (!stored) {
+      cachedMeta = { ...DEFAULT_META };
+      return cachedMeta;
+    }
+    const parsed = JSON.parse(stored);
+    if (parsed && typeof parsed === 'object') {
+      cachedMeta = { ...DEFAULT_META, ...parsed };
+      return cachedMeta;
+    }
+  } catch (err) {
+    // Ignore parse/storage errors and fall back to defaults.
+  }
+  cachedMeta = { ...DEFAULT_META };
+  return cachedMeta;
+}
+
+function writeMeta(meta) {
+  if (typeof window === 'undefined') {
+    cachedMeta = { ...DEFAULT_META, ...meta };
+    return;
+  }
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, JSON.stringify(meta));
+  } catch (err) {
+    // Ignore persistence issues.
+  }
+  cachedMeta = meta;
+}
+
+function sanitiseMetaPatch(patch) {
+  const normalised = {};
+  if (Object.prototype.hasOwnProperty.call(patch, 'highestUnlockedLevel')) {
+    const raw = Number.parseInt(patch.highestUnlockedLevel, 10);
+    if (Number.isFinite(raw) && raw >= 1) {
+      normalised.highestUnlockedLevel = raw;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'bestScore')) {
+    const raw = Number.parseInt(patch.bestScore, 10);
+    if (Number.isFinite(raw) && raw >= 0) {
+      normalised.bestScore = raw;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'preferredTheme')) {
+    const raw = patch.preferredTheme;
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      normalised.preferredTheme = raw;
+    } else if (raw === null) {
+      normalised.preferredTheme = null;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'difficulty')) {
+    const raw = patch.difficulty;
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      normalised.difficulty = raw.trim();
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'assist')) {
+    normalised.assist = Boolean(patch.assist);
+  }
+  return normalised;
+}
+
+export function getStoredMeta() {
+  return { ...DEFAULT_META, ...readRawMeta() };
+}
+
+export function getMetaValue(key, fallback = null) {
+  const meta = getStoredMeta();
+  if (Object.prototype.hasOwnProperty.call(meta, key)) {
+    return meta[key];
+  }
+  return fallback;
+}
+
+export function updateStoredMeta(patch) {
+  const current = getStoredMeta();
+  const updates = sanitiseMetaPatch(patch);
+  if (!Object.keys(updates).length) {
+    return current;
+  }
+  const next = { ...current, ...updates };
+  writeMeta(next);
+  return next;
+}
+
+export function resetStoredMeta() {
+  writeMeta({ ...DEFAULT_META });
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -15,6 +15,7 @@ import {
   setDifficultyMode as persistDifficultyMode,
   onDifficultyModeChange as subscribeDifficultyMode,
 } from './difficulty.js';
+import { getMetaValue, updateStoredMeta } from './storage.js';
 
 const HUD_STYLE_ID = 'hud-compact-style';
 
@@ -635,9 +636,14 @@ function normalizeWeaponLabel(label) {
 }
 
 function readStoredTheme() {
+  const metaTheme = getMetaValue('preferredTheme', null);
+  if (metaTheme && THEMES[metaTheme]) {
+    return metaTheme;
+  }
   try {
     const stored = window.localStorage?.getItem(THEME_STORAGE_KEY);
     if (stored && THEMES[stored]) {
+      updateStoredMeta({ preferredTheme: stored });
       return stored;
     }
   } catch (err) {
@@ -649,12 +655,18 @@ function readStoredTheme() {
 let activeThemeKey = readStoredTheme();
 
 function readStoredAssist() {
+  const metaAssist = getMetaValue('assist', false);
+  if (typeof metaAssist === 'boolean') {
+    return metaAssist;
+  }
   try {
     const stored = window.localStorage?.getItem(ASSIST_STORAGE_KEY);
     if (stored === 'on') {
+      updateStoredMeta({ assist: true });
       return true;
     }
     if (stored === 'off') {
+      updateStoredMeta({ assist: false });
       return false;
     }
   } catch (err) {
@@ -786,11 +798,7 @@ function setThemeInternal(key, persist = true) {
   activeThemeKey = key;
   syncThemeControl();
   if (persist) {
-    try {
-      window.localStorage?.setItem(THEME_STORAGE_KEY, key);
-    } catch (err) {
-      /* ignore storage errors */
-    }
+    updateStoredMeta({ preferredTheme: key });
   }
   emitThemeChange();
 }
@@ -840,11 +848,7 @@ function setAssistModeInternal(enabled, { persist = true } = {}) {
   assistMode = value;
   syncAssistToggle();
   if (persist) {
-    try {
-      window.localStorage?.setItem(ASSIST_STORAGE_KEY, assistMode ? 'on' : 'off');
-    } catch (err) {
-      /* ignore storage errors */
-    }
+    updateStoredMeta({ assist: assistMode });
   }
   emitAssistChange();
 }


### PR DESCRIPTION
## Summary
- add a shared localStorage meta store for highest unlocked level, best score, theme, difficulty, and assist state
- refresh the start overlay with progress summaries, conditional Continue flow, and unlocked level selection
- introduce an Esc-driven options overlay with volume, theme, difficulty, and assist controls plus audio volume support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2fa7855348321918a1f8f688a9b48