### PR TITLE
Fix spawn pacing and HUD event wiring

### DIFF
--- a/src/difficulty.js
+++ b/src/difficulty.js
@@ -1,17 +1,196 @@
 /**
  * difficulty.js — player-selectable global difficulty multipliers.
  */
+// CHANGELOG: Added spawn configuration resolver and difficulty event emissions.
 
 export const DIFFICULTY = Object.freeze({
   easy: { density: 0.85, speed: 0.9, hp: 0.9 },
   normal: { density: 1, speed: 1, hp: 1 },
-  hard: { density: 1.2, speed: 1.1, hp: 1.1 },
+  hard: { density: 1.25, speed: 1.1, hp: 1.1 },
 });
 
 import { getMetaValue, updateStoredMeta } from './storage.js';
+import { GameEvents } from './events.js';
 
 const DEFAULT_MODE = 'normal';
 const listeners = new Set();
+
+const DEFAULT_LEVEL_KEY = 'L1';
+
+const BASE_SPAWN_CONFIG = Object.freeze({
+  asteroids: {
+    interval: 1.9,
+    countRange: [1, 3],
+    params: { vy: [70, 140], vx: [-40, 40] },
+  },
+  waves: {
+    initialDelay: 3,
+    intervalRange: [9, 11],
+    patterns: [
+      { weight: 1, entries: [{ type: 'strafer', count: 3, params: { fireCd: [900, 1300] } }] },
+      { weight: 0.8, entries: [{ type: 'drone', count: 4, params: { steerAccel: 28 } }] },
+      { weight: 0.6, entries: [{ type: 'asteroid', count: 6, params: { vy: [90, 160] } }] },
+    ],
+  },
+});
+
+const LEVEL_SPAWN_OVERRIDES = Object.freeze({
+  L1: {
+    asteroids: {
+      interval: 1.7,
+      countRange: [1, 3],
+      params: { vy: [80, 150], vx: [-60, 60], radiusMin: 10, radiusMax: 22 },
+    },
+    waves: {
+      initialDelay: 2.4,
+      intervalRange: [8, 10],
+      patterns: [
+        { weight: 1, entries: [{ type: 'strafer', count: 3, params: { fireCd: [900, 1200] } }] },
+        { weight: 0.9, entries: [{ type: 'drone', count: 4, params: { steerAccel: 28 } }] },
+        { weight: 0.7, entries: [{ type: 'asteroid', count: 5, params: { vy: [80, 140] } }] },
+        { weight: 0.6, entries: [{ type: 'turret', count: 1, params: { fireCd: [1400, 2000] } }] },
+      ],
+    },
+  },
+  L2: {
+    asteroids: {
+      interval: 1.4,
+      countRange: [2, 3],
+      params: { vy: [90, 170], vx: [-80, 80], radiusMin: 12, radiusMax: 26 },
+    },
+    waves: {
+      initialDelay: 2.6,
+      intervalRange: [7.2, 9],
+      patterns: [
+        { weight: 1.1, entries: [{ type: 'drone', count: 5, params: { steerAccel: 34 } }] },
+        { weight: 0.8, entries: [{ type: 'strafer', count: 4, params: { fireCd: [800, 1200] } }] },
+        { weight: 0.7, entries: [{ type: 'turret', count: 2, params: { fireCd: [1100, 1500], bulletSpeed: 260 } }] },
+        { weight: 0.6, entries: [{ type: 'asteroid', count: 7, params: { vy: [100, 180] } }] },
+      ],
+    },
+  },
+});
+
+function cloneConfig(config) {
+  return JSON.parse(JSON.stringify(config));
+}
+
+function mergeSpawnConfig(base, override = {}) {
+  const merged = cloneConfig(base);
+  if (!override) {
+    return merged;
+  }
+  if (override.asteroids) {
+    merged.asteroids = {
+      ...merged.asteroids,
+      ...cloneConfig(override.asteroids),
+      params: {
+        ...cloneConfig(merged.asteroids.params ?? {}),
+        ...cloneConfig(override.asteroids.params ?? {}),
+      },
+    };
+  }
+  if (override.waves) {
+    merged.waves = {
+      ...merged.waves,
+      ...cloneConfig(override.waves),
+    };
+    if (override.waves.patterns) {
+      merged.waves.patterns = override.waves.patterns.map((pattern) => cloneConfig(pattern));
+    }
+  }
+  return merged;
+}
+
+function scaleValue(value, factor) {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  return value * factor;
+}
+
+function scalePatternEntry(entry, density, speed) {
+  const scaled = cloneConfig(entry);
+  const count = Number.isFinite(entry.count) ? entry.count : 1;
+  scaled.count = Math.max(1, Math.round(count * density));
+  if (scaled.params) {
+    if (Number.isFinite(scaled.params.speedMin)) {
+      scaled.params.speedMin = scaleValue(scaled.params.speedMin, speed);
+    }
+    if (Number.isFinite(scaled.params.speedMax)) {
+      scaled.params.speedMax = scaleValue(scaled.params.speedMax, speed);
+    }
+    if (Array.isArray(scaled.params.vy)) {
+      scaled.params.vy = scaled.params.vy.map((v) => scaleValue(v, speed));
+    }
+    if (Array.isArray(scaled.params.fireCd)) {
+      scaled.params.fireCd = scaled.params.fireCd.map((v) => Math.max(400, v / speed));
+    }
+  }
+  return scaled;
+}
+
+function scaleSpawnConfig(config, mode) {
+  const multipliers = DIFFICULTY[mode] ?? DIFFICULTY[DEFAULT_MODE];
+  const density = Number.isFinite(multipliers?.density) ? multipliers.density : 1;
+  const speed = Number.isFinite(multipliers?.speed) ? multipliers.speed : 1;
+  const scaled = cloneConfig(config);
+  if (scaled.asteroids) {
+    if (Number.isFinite(scaled.asteroids.interval)) {
+      scaled.asteroids.interval = Math.max(0.6, scaled.asteroids.interval / density);
+    }
+    if (Array.isArray(scaled.asteroids.countRange)) {
+      scaled.asteroids.countRange = scaled.asteroids.countRange.map((value) =>
+        Math.max(1, Math.round(value * density)),
+      );
+    } else if (Number.isFinite(scaled.asteroids.count)) {
+      scaled.asteroids.count = Math.max(1, Math.round(scaled.asteroids.count * density));
+    }
+    if (scaled.asteroids.params) {
+      if (Array.isArray(scaled.asteroids.params.vy)) {
+        scaled.asteroids.params.vy = scaled.asteroids.params.vy.map((value) => scaleValue(value, speed));
+      }
+    }
+  }
+  if (scaled.waves) {
+    if (Array.isArray(scaled.waves.intervalRange)) {
+      scaled.waves.intervalRange = scaled.waves.intervalRange.map((value) => Math.max(4, value / density));
+    }
+    if (scaled.waves.patterns) {
+      scaled.waves.patterns = scaled.waves.patterns.map((pattern) => {
+        const weight = Number.isFinite(pattern.weight) ? pattern.weight : 1;
+        return {
+          ...pattern,
+          weight,
+          entries: Array.isArray(pattern.entries)
+            ? pattern.entries.map((entry) => scalePatternEntry(entry, density, speed))
+            : [],
+        };
+      });
+    }
+  }
+  return scaled;
+}
+
+function resolveLevelKey(level) {
+  if (!level) {
+    return DEFAULT_LEVEL_KEY;
+  }
+  if (typeof level === 'string') {
+    return level;
+  }
+  if (typeof level.key === 'string') {
+    return level.key;
+  }
+  return DEFAULT_LEVEL_KEY;
+}
+
+export function getDifficultyConfig(mode = currentMode, level = DEFAULT_LEVEL_KEY) {
+  const key = resolveLevelKey(level);
+  const base = mergeSpawnConfig(BASE_SPAWN_CONFIG, LEVEL_SPAWN_OVERRIDES[key] ?? {});
+  const scaled = scaleSpawnConfig(base, mode);
+  return { ...scaled, difficulty: mode, level: key };
+}
 
 function normaliseMode(mode) {
   if (typeof mode !== 'string') {
@@ -40,6 +219,10 @@ function emitChange(mode) {
       /* swallow listener errors */
     }
   });
+  GameEvents.emit('difficulty:changed', {
+    mode,
+    config: getDifficultyConfig(mode),
+  });
 }
 
 export function getDifficultyMode() {
@@ -57,6 +240,10 @@ export function setDifficultyMode(mode, { persist = true } = {}) {
   }
   emitChange(currentMode);
   return currentMode;
+}
+
+export function setDifficulty(mode, options) {
+  return setDifficultyMode(mode, options);
 }
 
 export function getDifficultyMultipliers(mode = currentMode) {

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,50 @@
+// CHANGELOG: Added centralised pub/sub for gameplay state events.
+
+const subscribers = new Map();
+
+function getBucket(event) {
+  if (!subscribers.has(event)) {
+    subscribers.set(event, new Set());
+  }
+  return subscribers.get(event);
+}
+
+export function on(event, handler) {
+  if (typeof handler !== 'function') {
+    return () => {};
+  }
+  const bucket = getBucket(event);
+  bucket.add(handler);
+  return () => {
+    bucket.delete(handler);
+  };
+}
+
+export function once(event, handler) {
+  if (typeof handler !== 'function') {
+    return () => {};
+  }
+  const off = on(event, (...args) => {
+    off();
+    handler(...args);
+  });
+  return off;
+}
+
+export function emit(event, payload) {
+  const bucket = subscribers.get(event);
+  if (!bucket || bucket.size === 0) {
+    return;
+  }
+  bucket.forEach((handler) => {
+    try {
+      handler(payload);
+    } catch (error) {
+      if (console && typeof console.error === 'function') {
+        console.error('[GameEvents] handler error for', event, error);
+      }
+    }
+  });
+}
+
+export const GameEvents = Object.freeze({ on, once, emit });

--- a/src/spawner.js
+++ b/src/spawner.js
@@ -1,0 +1,154 @@
+// CHANGELOG: Added continuous enemy and asteroid spawn scheduler.
+
+import { spawn } from './enemies.js';
+import { GameEvents } from './events.js';
+
+const spawner = {
+  state: null,
+  config: null,
+  asteroidTimer: 0,
+  waveTimer: 0,
+  waveCount: 0,
+  debug: false,
+};
+
+function getDebugFlag() {
+  if (typeof window !== 'undefined' && typeof window.__rsrDebug !== 'undefined') {
+    return Boolean(window.__rsrDebug);
+  }
+  return spawner.debug;
+}
+
+function rand(min, max) {
+  const lo = Number.isFinite(min) ? min : 0;
+  const hi = Number.isFinite(max) ? max : lo;
+  if (hi <= lo) {
+    return lo;
+  }
+  return lo + Math.random() * (hi - lo);
+}
+
+function randInt(min, max) {
+  return Math.round(rand(min, max));
+}
+
+function weightedPick(patterns = []) {
+  const entries = patterns.filter((pattern) => pattern && pattern.entries?.length);
+  if (!entries.length) {
+    return null;
+  }
+  const totalWeight = entries.reduce((sum, pattern) => sum + Math.max(0.01, Number(pattern.weight) || 0), 0);
+  let roll = Math.random() * totalWeight;
+  for (const pattern of entries) {
+    roll -= Math.max(0.01, Number(pattern.weight) || 0);
+    if (roll <= 0) {
+      return pattern;
+    }
+  }
+  return entries[entries.length - 1];
+}
+
+function spawnAsteroidBatch(state, config = {}) {
+  const { countRange, count, params = {}, intervalJitter = 0.35 } = config;
+  const batchCount = Array.isArray(countRange)
+    ? randInt(countRange[0], countRange[1])
+    : Math.max(1, Math.round(Number.isFinite(count) ? count : 1));
+  spawn(state, 'asteroid', { count: batchCount, ...params });
+  if (getDebugFlag()) {
+    console.log('[RSR][spawn] asteroid batch', { batchCount, params });
+  }
+  const baseInterval = Number.isFinite(config.interval) ? config.interval : 1.5;
+  const jitter = baseInterval * intervalJitter;
+  return Math.max(0.6, baseInterval + rand(-jitter, jitter));
+}
+
+function spawnWave(state, pattern) {
+  if (!pattern || !Array.isArray(pattern.entries)) {
+    return;
+  }
+  pattern.entries.forEach((entry) => {
+    if (!entry?.type) {
+      return;
+    }
+    spawn(state, entry.type, {
+      count: entry.count,
+      params: entry.params,
+    });
+  });
+  spawner.waveCount += 1;
+  if (getDebugFlag()) {
+    console.log('[RSR][spawn] wave', { index: spawner.waveCount, pattern });
+  }
+  GameEvents.emit('wave:spawned', {
+    index: spawner.waveCount,
+    pattern,
+  });
+}
+
+function resetTimers() {
+  spawner.asteroidTimer = 0;
+  spawner.waveTimer = 0;
+  spawner.waveCount = 0;
+}
+
+export function configureSpawner(state) {
+  spawner.state = state;
+  spawner.debug = getDebugFlag();
+}
+
+export function startLevelSpawns(config) {
+  if (!spawner.state) {
+    return;
+  }
+  spawner.config = config;
+  resetTimers();
+  const asteroidCfg = config?.asteroids ?? {};
+  const waveCfg = config?.waves ?? {};
+  spawner.asteroidTimer = Number.isFinite(asteroidCfg.interval) ? asteroidCfg.interval : 1.5;
+  spawner.waveTimer = Number.isFinite(waveCfg.initialDelay) ? waveCfg.initialDelay : 4;
+  if (getDebugFlag()) {
+    console.log('[RSR][spawn] start level', { config });
+  }
+}
+
+export function stopLevelSpawns() {
+  spawner.config = null;
+  resetTimers();
+}
+
+export function tickSpawner(dt) {
+  const state = spawner.state;
+  if (!state || !spawner.config || !state.running || state.paused) {
+    return;
+  }
+  const asteroidCfg = spawner.config.asteroids ?? {};
+  const waveCfg = spawner.config.waves ?? {};
+  if (asteroidCfg && state.lives > 0) {
+    spawner.asteroidTimer -= dt;
+    if (spawner.asteroidTimer <= 0) {
+      spawner.asteroidTimer = spawnAsteroidBatch(state, asteroidCfg);
+    }
+  }
+  if (waveCfg && state.lives > 0 && !state.boss && !state.bossSpawned) {
+    spawner.waveTimer -= dt;
+    if (spawner.waveTimer <= 0) {
+      const pattern = weightedPick(waveCfg.patterns);
+      if (pattern) {
+        spawnWave(state, pattern);
+      }
+      const [minGap, maxGap] = Array.isArray(waveCfg.intervalRange)
+        ? waveCfg.intervalRange
+        : [waveCfg.interval ?? 8, (waveCfg.interval ?? 8) + 2];
+      spawner.waveTimer = Math.max(4, rand(minGap, maxGap));
+    }
+  }
+}
+
+export function getSpawnConfig() {
+  return spawner.config;
+}
+
+export function resetSpawner() {
+  stopLevelSpawns();
+  spawner.state = null;
+}


### PR DESCRIPTION
## Summary
- add a GameEvents pub/sub bus and subscribe the HUD to lives, shield, score, weapon, and power-up changes
- centralise damage, score, and difficulty handling in the main loop while emitting debug logs and lifecycle events
- add a difficulty-aware spawner that keeps asteroid fields and enemy waves active across both levels

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e303fb7e488321bffa66363d163aa3