### PR TITLE
Enhance themes with gameplay behaviours and overlays

### DIFF
--- a/src/levels.js
+++ b/src/levels.js
@@ -1,9 +1,12 @@
+import { getThemeBehaviour } from './themes.js';
+
 export const LEVELS = [
   {
     key: 'L1',
     name: 'Debris Drift',
     duration: 90,
     theme: 'synth-horizon',
+    themeBehaviour: getThemeBehaviour('synth-horizon'),
     overlays: { tint: 'rgba(0,0,0,0.0)' },
     starfield: {
       density: 0.9,
@@ -24,6 +27,7 @@ export const LEVELS = [
     name: 'Ion Squalls',
     duration: 105,
     theme: 'luminous-depths',
+    themeBehaviour: getThemeBehaviour('luminous-depths'),
     overlays: { tint: 'rgba(80,0,120,0.06)' },
     starfield: {
       density: 1.35,
@@ -38,5 +42,27 @@ export const LEVELS = [
     ],
     boss: { kind: 'warden', hp: 440, phases: [0.8, 0.5] },
     mutators: { windX: 25, squalls: true },
+  },
+  {
+    key: 'L3',
+    name: 'Ember Breaker',
+    duration: 110,
+    theme: 'ember-overdrive',
+    themeBehaviour: getThemeBehaviour('ember-overdrive'),
+    overlays: { tint: 'rgba(120,40,0,0.08)' },
+    starfield: {
+      density: 1.1,
+      twinkle: { amplitude: 0.28, speed: 1.35 },
+      sizeRange: [1.1, 2.1],
+    },
+    enemyWeights: { asteroid: 0.8, strafer: 1.1, drone: 0.9, turret: 0.6 },
+    waves: [
+      { at: 3.5, type: 'asteroid', count: 5, params: { vy: [90, 150] } },
+      { at: 9.0, type: 'strafer', count: 2, params: { fireCd: [900, 1400] } },
+      { at: 16.0, type: 'turret', count: 1, params: { bulletSpeed: 260 } },
+      { at: 28.0, type: 'strafer', count: 3, params: { speedMin: 150, speedMax: 220 } },
+    ],
+    boss: { kind: 'overdrive', hp: 520, phases: [0.75, 0.45] },
+    mutators: { windX: -18, squalls: false },
   },
 ];

--- a/src/powerups.js
+++ b/src/powerups.js
@@ -46,7 +46,10 @@ export function resetPowerTimers() {
 export function maybeSpawnPowerup(state, now) {
   const interval = state.level?.powerups?.intervalMs ?? 12000;
   const assistFactor = state.assistEnabled ? 2 / 3 : 1;
-  const targetInterval = interval * assistFactor;
+  const themeFactor = Number.isFinite(state.themeFx?.powerupIntervalMultiplier)
+    ? Math.max(0.2, state.themeFx.powerupIntervalMultiplier)
+    : 1;
+  const targetInterval = interval * assistFactor * themeFactor;
   if (now - spawnState.last < targetInterval) {
     return;
   }
@@ -90,8 +93,12 @@ export function applyPower(state, kind, now) {
   let duration = baseDuration;
   if (kind === 'shield') {
     const multiplier = state.runUpgrades?.shieldDurationMultiplier ?? 1;
-    duration = Math.round(baseDuration * multiplier);
+    duration = baseDuration * multiplier;
   }
+  const durationMultiplier = Number.isFinite(state.themeFx?.powerupDurationMultiplier)
+    ? Math.max(0.1, state.themeFx.powerupDurationMultiplier)
+    : 1;
+  duration = Math.round(duration * durationMultiplier);
   state.power.name = kind;
   state.power.until = now + duration;
   const label = kind.toUpperCase();

--- a/src/themes.js
+++ b/src/themes.js
@@ -507,6 +507,134 @@ export const THEMES = {
   },
 };
 
+const THEME_BEHAVIOURS = {
+  'synth-horizon': {
+    key: 'synth-horizon',
+    icon: '🌅',
+    title: 'Neon Horizon',
+    summary: 'Neon lasers, frequent powerups, balanced pace.',
+    overlay: {
+      kind: 'laser',
+      intensity: 0.28,
+      speed: 0.32,
+      spacing: 240,
+      colours: {
+        primary: 'rgba(0, 229, 255, 0.22)',
+        secondary: 'rgba(255, 61, 247, 0.16)',
+      },
+    },
+    spawnModifiers: {
+      powerupIntervalMultiplier: 0.75,
+    },
+    paletteAdjustments: {
+      particles: {
+        enemyHitDefault: '#4ffcff',
+        enemyHitStrafer: '#ff6aff',
+        bossHit: '#ff6aff',
+        bossCore: '#9dfdff',
+      },
+      bullets: {
+        playerLevels: ['#8cfbff', '#c4faff', '#fff4ff'],
+        highlight: '#ff92ff',
+        muzzleEdge: '#8cfbff',
+        enemyGlow: '#66fbffaa',
+      },
+      stars: {
+        bright: '#7af8ff',
+        dim: '#ff74ff',
+      },
+    },
+  },
+  'luminous-depths': {
+    key: 'luminous-depths',
+    icon: '💧',
+    title: 'Luminous Depths',
+    summary: 'Veiled fog, slower movement, heavy drone patrols.',
+    overlay: {
+      kind: 'fog',
+      intensity: 0.46,
+      speed: 0.18,
+      colours: {
+        near: 'rgba(36, 245, 217, 0.2)',
+        far: 'rgba(22, 128, 255, 0.08)',
+        highlight: 'rgba(110, 255, 255, 0.12)',
+      },
+    },
+    spawnModifiers: {
+      enemySpeedMultiplier: 0.85,
+      powerupIntervalMultiplier: 1.1,
+      enemyWeightMultipliers: {
+        asteroid: 0.7,
+        strafer: 0.6,
+        drone: 1.5,
+      },
+    },
+    paletteAdjustments: {
+      particles: {
+        enemyHitDefault: '#5ae9ff',
+        enemyHitStrafer: '#1a9dff',
+        bossHit: '#1a9dff',
+        bossCore: '#8cfaff',
+      },
+      bullets: {
+        playerLevels: ['#76f5ff', '#b3f9ff', '#e7fdff'],
+        highlight: '#f1ffff',
+        muzzleEdge: '#b3f9ff',
+        enemyGlow: '#5defffaa',
+      },
+      stars: {
+        bright: '#76f5ff',
+        dim: '#2f96ff',
+      },
+    },
+  },
+  'ember-overdrive': {
+    key: 'ember-overdrive',
+    icon: '🔥',
+    title: 'Ember Overdrive',
+    summary: 'Heat shimmer, faster hostiles, fleeting boosts.',
+    overlay: {
+      kind: 'heat',
+      intensity: 0.4,
+      speed: 0.5,
+      waves: 4,
+      colours: {
+        hot: 'rgba(255, 123, 57, 0.24)',
+        warm: 'rgba(255, 189, 45, 0.18)',
+        highlight: 'rgba(255, 228, 178, 0.14)',
+      },
+    },
+    spawnModifiers: {
+      enemySpeedMultiplier: 1.25,
+      powerupDurationMultiplier: 0.65,
+      enemyWeightMultipliers: {
+        asteroid: 0.9,
+        drone: 0.85,
+        strafer: 1.25,
+        turret: 1.15,
+      },
+    },
+    paletteAdjustments: {
+      particles: {
+        enemyHitDefault: '#ffc96b',
+        enemyHitStrafer: '#ff7e42',
+        bossHit: '#ff7e42',
+        bossCore: '#ffe6a6',
+      },
+      bullets: {
+        playerLevels: ['#ffb867', '#ffd091', '#ffe9bb'],
+        highlight: '#fff3cf',
+        muzzleEdge: '#ffd091',
+        enemyGlow: '#ffb96baa',
+      },
+      stars: {
+        bright: '#ffd66e',
+        dim: '#ff6b39',
+      },
+    },
+  },
+};
+
 export const DEFAULT_THEME_PALETTE = THEMES[DEFAULT_THEME_KEY].palette;
 
 export function resolvePaletteSection(palette, section) {
@@ -525,4 +653,82 @@ export function getThemeLabel(key) {
 
 export function getThemePalette(key) {
   return THEMES[key]?.palette ?? THEMES[DEFAULT_THEME_KEY].palette;
+}
+
+function clonePaletteAdjustments(adjustments = {}) {
+  const clone = {};
+  for (const [section, value] of Object.entries(adjustments)) {
+    if (Array.isArray(value)) {
+      clone[section] = value.slice();
+    } else if (value && typeof value === 'object') {
+      const sectionClone = {};
+      for (const [key, entry] of Object.entries(value)) {
+        sectionClone[key] = Array.isArray(entry)
+          ? entry.slice()
+          : entry;
+      }
+      clone[section] = sectionClone;
+    } else {
+      clone[section] = value;
+    }
+  }
+  return clone;
+}
+
+function cloneBehaviour(behaviour) {
+  if (!behaviour) {
+    return null;
+  }
+  return {
+    ...behaviour,
+    overlay: behaviour.overlay
+      ? {
+          ...behaviour.overlay,
+          colours: behaviour.overlay.colours ? { ...behaviour.overlay.colours } : undefined,
+        }
+      : null,
+    spawnModifiers: behaviour.spawnModifiers
+      ? {
+          ...behaviour.spawnModifiers,
+          enemyWeightMultipliers: behaviour.spawnModifiers.enemyWeightMultipliers
+            ? { ...behaviour.spawnModifiers.enemyWeightMultipliers }
+            : undefined,
+        }
+      : undefined,
+    paletteAdjustments: behaviour.paletteAdjustments
+      ? clonePaletteAdjustments(behaviour.paletteAdjustments)
+      : undefined,
+  };
+}
+
+export function getThemeBehaviour(key) {
+  return cloneBehaviour(THEME_BEHAVIOURS[key] ?? null);
+}
+
+export function applyThemeBehaviourToPalette(palette, behaviour) {
+  const base = palette ?? DEFAULT_THEME_PALETTE;
+  const adjustments = behaviour?.paletteAdjustments;
+  if (!adjustments || !Object.keys(adjustments).length) {
+    return base;
+  }
+  const merged = { ...base };
+  for (const [section, overrides] of Object.entries(adjustments)) {
+    if (!overrides) {
+      continue;
+    }
+    if (Array.isArray(overrides)) {
+      merged[section] = overrides.slice();
+      continue;
+    }
+    const baseSection = base[section];
+    const sectionClone =
+      baseSection && typeof baseSection === 'object' && !Array.isArray(baseSection)
+        ? { ...baseSection }
+        : {};
+    for (const [key, value] of Object.entries(overrides)) {
+      sectionClone[key] = Array.isArray(value) ? value.slice() : value;
+    }
+    merged[section] = sectionClone;
+  }
+  return merged;
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -1091,7 +1091,7 @@ export function updatePower(label) {
   setHUDPowerup(label);
 }
 
-export function updateLevelChip({ levelIndex, name, mutators } = {}) {
+export function updateLevelChip({ levelIndex, name, mutators, theme } = {}) {
   if (!hudLevel) {
     return;
   }
@@ -1103,6 +1103,12 @@ export function updateLevelChip({ levelIndex, name, mutators } = {}) {
   const cleanName = typeof name === 'string' ? name.trim() : '';
   if (cleanName) {
     parts.push(cleanName);
+  }
+  const themeLabel = typeof theme?.label === 'string' ? theme.label.trim() : '';
+  const themeIcon = typeof theme?.icon === 'string' ? theme.icon.trim() : '';
+  if (themeLabel) {
+    const decorated = themeIcon ? `${themeIcon} ${themeLabel}` : themeLabel;
+    parts.push(decorated);
   }
   const baseLabel = parts.length ? parts.join(' · ') : '—';
   if (hudLevelLabel) {


### PR DESCRIPTION
## Summary
- define per-theme behaviour profiles that tweak colours, overlays, and mechanical modifiers
- attach theme behaviours to levels (including a new Ember Breaker sector) and apply them when a level starts
- update rendering, enemy pacing, power-up timing, and HUD cues to reflect the active sector theme

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e32e242b9883219e52aa240d07b545