### PR TITLE
Add campaign story beats for level intros and outros

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,11 @@
   .overlay-progress{margin:0.6rem 0 0; font-size:.9rem; letter-spacing:.05em;}
   .overlay-progress--meta{margin-top:.3rem; font-size:.82rem; opacity:.8;}
   .overlay-hint{margin:1.2rem 0 0; font-size:.78rem; opacity:.72; letter-spacing:.08em;}
+  .story-card{display:flex; flex-direction:column; align-items:center; gap:.35rem; text-align:center;}
+  .story-card h2{margin:.1rem 0 .35rem; font-size:1.4rem; letter-spacing:.16em; text-transform:uppercase;}
+  .story-card__body{display:flex; flex-direction:column; gap:.3rem; font-size:.95rem; line-height:1.45; max-width:28rem;}
+  .story-card__line{margin:0;}
+  .story-card__hint{margin:.8rem 0 0; font-size:.78rem; letter-spacing:.08em; opacity:.72; text-transform:uppercase;}
   .ship-select{margin:1.4rem 0 1.2rem; padding:1rem; border-radius:14px; border:1px solid #00e5ff22; background:#0a0d1acc; box-shadow:0 0 12px #00e5ff11 inset;}
   .ship-select__label{margin:0; text-transform:uppercase; letter-spacing:.12em; font-size:.78rem; opacity:.78; text-align:center;}
   .ship-select__grid{margin-top:.6rem; display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:.75rem;}

--- a/src/story.js
+++ b/src/story.js
@@ -1,0 +1,69 @@
+export const STORY_BEATS = [
+  {
+    levelKey: 'L1',
+    phase: 'intro',
+    title: 'Debris Drift Briefing',
+    textLines: [
+      'Scavenger beacons flicker through shattered hulls.',
+      'Keep the escort lane clear as you sweep the wreck-line.',
+    ],
+  },
+  {
+    levelKey: 'L1',
+    phase: 'outro',
+    title: 'Drift Secured',
+    textLines: [
+      'Beacon sweep reports no hostile pings remaining.',
+      'Convoy engines spin up to cruise velocity.',
+    ],
+  },
+  {
+    levelKey: 'L2',
+    phase: 'intro',
+    title: 'Ion Squalls Run',
+    textLines: [
+      'Static storms shear the escort corridor tonight.',
+      'Ride the squalls and hold formation around the freighters.',
+    ],
+  },
+  {
+    levelKey: 'L2',
+    phase: 'outro',
+    title: 'Squalls Cleared',
+    textLines: [
+      'The Warden’s core implodes… telemetry stable.',
+      'Relay ships merge back into the lane under your cover.',
+    ],
+  },
+  {
+    levelKey: 'L3',
+    phase: 'intro',
+    title: 'Ember Breaker Push',
+    textLines: [
+      'Forge furnaces ignite the void lanes at random.',
+      'Disarm the breakers before the route melts shut.',
+    ],
+  },
+  {
+    levelKey: 'L3',
+    phase: 'outro',
+    title: 'Breaker Silent',
+    textLines: [
+      'Overdrive heart cools to slag; transit lanes reopen.',
+      'Fleet charts mark the sector safe for convoy passage.',
+    ],
+  },
+];
+
+export function getStoryBeat(levelKey, phase) {
+  if (!levelKey || !phase) {
+    return null;
+  }
+  const key = `${levelKey}`.toUpperCase();
+  const phaseKey = `${phase}`.toLowerCase();
+  return (
+    STORY_BEATS.find(
+      (beat) => beat.levelKey === key && (beat.phase ?? '').toLowerCase() === phaseKey,
+    ) ?? null
+  );
+}


### PR DESCRIPTION
## Summary
- define sector narrative beats and lookup helper in a dedicated story module
- trigger concise intro and outro overlays with skip support and state cleanup
- style the story overlay markup to match the existing HUD aesthetics

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e357298e808321aceeddb29b62816e