### PR TITLE
Implement canvas menu state management and difficulty dropdown handlers

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -92,6 +92,7 @@ function logInteraction(kind, name, region) {
 export const ui = {
   buttonRegions,
   dropdownRegions,
+  isDiffOpen: false,
   resetRegions() {
     buttonRegions.length = 0;
     dropdownRegions.length = 0;
@@ -145,6 +146,30 @@ export const ui = {
     if (!key) {
       return;
     }
+    const root = typeof globalThis !== 'undefined' ? globalThis : window;
+    const appMain = root?.main;
+    switch (key) {
+      case 'startCampaign':
+        appMain?.setState?.('GAMEPLAY');
+        break;
+      case 'endless':
+        appMain?.setState?.('ENDLESS');
+        break;
+      case 'garage':
+        appMain?.setState?.('GARAGE');
+        break;
+      case 'achievements':
+        appMain?.setState?.('ACHIEVEMENTS');
+        break;
+      case 'options':
+        appMain?.setState?.('OPTIONS');
+        break;
+      case 'toggleDifficulty':
+        this.isDiffOpen = !this.isDiffOpen;
+        break;
+      default:
+        break;
+    }
     const handler = buttonHandlers.get(key);
     if (handler) {
       handler(region);
@@ -155,6 +180,23 @@ export const ui = {
     const key = sanitizeName(name);
     if (!key) {
       return;
+    }
+    if (key.startsWith('difficulty_')) {
+      const diff = key.split('_')[1];
+      if (diff) {
+        const root = typeof globalThis !== 'undefined' ? globalThis : window;
+        const appMain = root?.main;
+        if (appMain?.settings) {
+          appMain.settings.difficulty = diff;
+        }
+        this.isDiffOpen = false;
+        try {
+          root?.localStorage?.setItem?.('difficulty', diff);
+        } catch (err) {
+          /* ignore storage errors */
+        }
+        setDifficulty(diff);
+      }
     }
     const handler = dropdownHandlers.get(key);
     if (handler) {


### PR DESCRIPTION
## Summary
- add an application view state machine with a global `main` interface to drive menu, gameplay, endless, and overlay transitions
- update menu overlays and input handlers to route through the shared state transitions and refresh the correct screens
- hook canvas button and dropdown interactions to trigger state changes and persist difficulty selection in local storage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5cb69940c8321b140244f0e941d9b