### PR TITLE
Reset UI hit regions on state transitions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3205,9 +3205,6 @@ function normaliseViewState(value) {
 }
 
 function resetUiInteractionState() {
-  if (ui && typeof ui.resetRegions === 'function') {
-    ui.resetRegions();
-  }
   if (ui && typeof ui === 'object') {
     ui.isDiffOpen = false;
   }
@@ -3228,6 +3225,9 @@ function setAppState(newState, options = {}) {
   currentViewState = next;
   const isResume = next === APP_VIEW_STATES.GAMEPLAY && options.resume;
   if (!isResume) {
+    if (ui && typeof ui.resetRegions === 'function') {
+      ui.resetRegions();
+    }
     resetUiInteractionState();
   }
   switch (next) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -47,8 +47,6 @@ const hudRoot = document.getElementById('hud');
 const overlay = document.getElementById('overlay');
 let difficultySelect = document.getElementById('difficulty-select');
 
-const buttonRegions = [];
-const dropdownRegions = [];
 const buttonHandlers = new Map();
 const dropdownHandlers = new Map();
 
@@ -126,21 +124,24 @@ function logInteraction(kind, name, region) {
 }
 
 export const ui = {
-  buttonRegions,
-  dropdownRegions,
+  buttonRegions: [],
+  dropdownRegions: [],
   isDiffOpen: false,
   debug: false,
   debugLastClick: null,
   resetRegions() {
-    buttonRegions.length = 0;
-    dropdownRegions.length = 0;
+    this.buttonRegions = [];
+    this.dropdownRegions = [];
   },
   registerButton(region) {
     const normalized = normalizeRegion(region);
     if (!normalized) {
       return null;
     }
-    buttonRegions.push(normalized);
+    if (!Array.isArray(this.buttonRegions)) {
+      this.buttonRegions = [];
+    }
+    this.buttonRegions.push(normalized);
     return normalized;
   },
   registerDropdown(region) {
@@ -148,7 +149,10 @@ export const ui = {
     if (!normalized) {
       return null;
     }
-    dropdownRegions.push(normalized);
+    if (!Array.isArray(this.dropdownRegions)) {
+      this.dropdownRegions = [];
+    }
+    this.dropdownRegions.push(normalized);
     return normalized;
   },
   bindButtonHandler(name, handler) {
@@ -251,16 +255,20 @@ export const ui = {
     if (this.debug) {
       this.drawDebugCrosshair();
     }
-    for (const region of buttonRegions) {
+    const buttons = Array.isArray(this.buttonRegions) ? this.buttonRegions : [];
+    for (const region of buttons) {
       if (isPointInsideRegion(mx, my, region)) {
         this.handleButton(region.name, region);
         return;
       }
     }
-    for (const region of dropdownRegions) {
-      if (isPointInsideRegion(mx, my, region)) {
-        this.handleDropdown(region.name, region);
-        return;
+    if (this.isDiffOpen) {
+      const dropdowns = Array.isArray(this.dropdownRegions) ? this.dropdownRegions : [];
+      for (const region of dropdowns) {
+        if (isPointInsideRegion(mx, my, region)) {
+          this.handleDropdown(region.name, region);
+          return;
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary
- reinitialize stored button and dropdown hit regions whenever menus redraw
- update click handling to search buttons before dropdowns and only when dropdowns are open
- clear UI hit regions on application state changes to prevent stale interactions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5db8ba8308321bb0b37f37eaf2bbd